### PR TITLE
Added functionality for pinned terms and to reuse terms with children.

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2016-05.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2016-05.xsd
@@ -4052,6 +4052,27 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="ReuseChildren" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if children of the source term should be reused, optional attribute.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsPinned" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if this term is pinned, optional attribute. Requires IsReused set to true.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="IsPinnedRoot" type="xsd:boolean" use="optional" default="false">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+              Declares if this term is the root of the pinned herarchy, optional attribute. Requires IsPinned and IsReused set to true.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="IsSourceTerm" type="xsd:boolean" use="optional" default="true">
           <xsd:annotation>
             <xsd:documentation xml:lang="en">


### PR DESCRIPTION
I added functionality in the schema for pinned terms and reused terms. I'm not sure if it is correct to do this in the 2016-05 version, but I couldn't find any guidance on this.

Changes required in PnP-Sites-Core has been added to PR #719 (OfficeDev/PnP-Sites-Core)

regards
Jens Otto
