### PR TITLE
Update ProvisioningSchema-2016-05-FullSample-02.xml

### DIFF
--- a/Samples/ProvisioningSchema-2016-05-FullSample-02.xml
+++ b/Samples/ProvisioningSchema-2016-05-FullSample-02.xml
@@ -369,13 +369,13 @@
         <!-- This is the custom WelcomePage for the ProjectDocumentSet ContentType -->
         <pnp:File Src="ProjectHomePage.aspx" Folder="_cts/ProjectDocumentSet/" Overwrite="true" />
 
-        <pnp:Directory Src="c:\LocalPath\StyleLibrary" Folder="Style%20Library" Overwrite="true"
+        <pnp:Directory Src="StyleLibrary" Folder="Style%20Library" Overwrite="true"
             Recursive="true" IncludedExtensions="*.css,*.js,*.woff" ExcludedExtensions="*.xml,*.json" />
         <pnp:Directory Src=".\Invoices" Folder="Invoices" Overwrite="true"
                     Recursive="false" MetadataMappingFile=".\InvoicesMetadata.json" />
-        <pnp:Directory Src="c:\LocalPath\Pages" Folder="{PagesLibrary}"
+        <pnp:Directory Src="Pages" Folder="{PagesLibrary}"
                     Overwrite="true" Recursive="true" Level="Published"
-                    MetadataMappingFile="c:\LocalPath\PagesMetadata.json" />
+                    MetadataMappingFile=".\PagesMetadata.json" />
 
       </pnp:Files>
 


### PR DESCRIPTION
pnp:Directory does not accept full paths, due to an issue in the FileSystemConnector.cs - ConstructPath function that strips out '\'