### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ which will provision SharePoint sites and other elements using this schema.
 
 # Current implemented version (in the PnP Provisioning Engine) 
 
-[Version 201605](OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2016-05.xsd)
+[Version 201705](OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2017-05.xsd)
 
 ## Current approved versions
 


### PR DESCRIPTION
The Current implemented version (in the PnP Provisioning Engine) was still referencing 201605 schema version while 201705 schema version is implemeted as far as I know. Couldn't quickly find official statement on this but verified by extracting a provisioning template using PowerShell and looking at the schema version.