### PR TITLE
Added support for Default Column Values

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2018-01.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2018-01.xsd
@@ -309,6 +309,14 @@
         </xsd:annotation>
       </xsd:element>
 
+      <xsd:element name="DefaultColumnValues" type="pnp:DefaultColumnValues" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Default Column Values entries of the Provisioning Template, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
       <xsd:element name="Security" type="pnp:Security" minOccurs="0" maxOccurs="1">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
@@ -1024,6 +1032,18 @@
     </xsd:sequence>
   </xsd:complexType>
 
+  <xsd:complexType name="DefaultColumnValues">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Default Column Values entries of the Provisioning Template, optional collection of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="DefaultColumnValue" type="pnp:DefaultColumnValue"
+                    minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
   <xsd:complexType name="Security">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
@@ -1405,6 +1425,30 @@
         </xsd:attribute>
       </xsd:extension>
     </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DefaultColumnValue" >
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        The Default Column Value of the Provisioning Template.
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Declares whether the Default Column Value has to overwrite an already existing entry, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    
+    <xsd:attribute name="Name" type="xsd:string" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          The Name of the column to set the default value on, required attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="StringDictionaryItem">
@@ -2443,6 +2487,14 @@
           <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
           <xsd:documentation xml:lang="en">
             The Property Bag entries of the Folder, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="DefaultColumnValues" type="pnp:DefaultColumnValues" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:appinfo>Added with schema version 201805</xsd:appinfo>
+          <xsd:documentation xml:lang="en">
+            The Default Column Values entries of the Folder, optional collection of elements.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:element>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ which will provision SharePoint sites and other elements using this schema.
 
 # Current default implemented version (in the PnP Provisioning Engine) 
 
-[Version 201705](OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2017-05.xsd)
+[Version 201801](OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2018-01.xsd)
 
 ## Current approved versions
 


### PR DESCRIPTION
I've added support to the schema for defining Default Column Values on a library. 

As described in issue #299 I've added an element "DefaultColumnValues" to [the Folder element of a library](https://github.com/SharePoint/PnP-Provisioning-Schema/blob/master/ProvisioningSchema-2018-01.md#folder) which is an optional collection of DefaultColumnValue elements.

An example of a library definition in which default column values are set:

```
<pnp:Lists>
    <pnp:ListInstance Title="Example">
        <pnp:Folders>
            <pnp:Folder Name="/"> <!-- Set the default column values on the root folder -->
                <pnp:DefaultColumnValues>
                    <pnp:DefaultColumnValue Name="Field-01">Foo</pnp:DefaultColumnValue>
                    <pnp:DefaultColumnValue Name="Field-02">Tokyo</pnp:DefaultColumnValue>
                </pnp:DefaultColumnValues>
            </pnp:Folder>
            <pnp:Folder Name="SubFolder-01">
                <pnp:DefaultColumnValues>
                    <pnp:DefaultColumnValue Name="Field-01" Overwrite="true">Bar</pnp:DefaultColumnValue>
                </pnp:DefaultColumnValues>
                <pnp:Folder Name="SubFolder-01-01">
                    <pnp:DefaultColumnValues>
                        <pnp:DefaultColumnValue Name="Field-01" Overwrite="true">Foo</pnp:DefaultColumnValue>
                    </pnp:DefaultColumnValues>                
                </pnp:Folder>
            </pnp:Folder>
            <pnp:Folder Name="SubFolder-02">
                <pnp:DefaultColumnValues>
                    <pnp:DefaultColumnValue Name="Field-01">Bar</pnp:DefaultColumnValue>
                    <pnp:DefaultColumnValue Name="Field-02" Overwrite="true">Paris</pnp:DefaultColumnValue>
                </pnp:DefaultColumnValues>
                <pnp:Folder Name="SubFolder-02-01" />
            </pnp:Folder>
            <pnp:Folder Name="SubFolder-03" />
        </pnp:Folders>
    </pnp:ListInstance>
</Lists>
```