### PR TITLE
Added support for removing field binding from content type and document set

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -3449,6 +3449,13 @@
       </xsd:annotation>
     </xsd:attribute>
 
+    <xsd:attribute name="Remove" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Declares if the field binding should be removed, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:attributeGroup>
 
   <xsd:complexType name="ListInstanceFieldRef">
@@ -3463,14 +3470,6 @@
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="Remove" type="xsd:boolean" use="optional" default="false">
-          <xsd:annotation>
-            <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
-            <xsd:documentation xml:lang="en">
-              Declares if the FieldRef should be Removed from the list or library, optional attribute.
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>


### PR DESCRIPTION
This pull request adds support for removing field binding from content type and document set (Shared Fields and Welcome Page fields). I have added Remove attribute to base type (FieldRefFull) and removed it from ListInstanceFieldRef in vNext schema (experimental branch), but it seems to be a little outdated in comparison to 2018-07 version.