### PR TITLE
Remove requirement for specifying group owner

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -1993,10 +1993,10 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Owner" type="xsd:string" use="required">
+    <xsd:attribute name="Owner" type="xsd:string" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          The Owner of the Site Group, required attribute.
+          The Owner of the Site Group, optional attribute. If not specified SharePoint will assign the user provisioning the schema as the group owner when creating a new group.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>


### PR DESCRIPTION
Specifying a group owner is not required by SharePoint when creating a group. It should therefore not be a requirement in the PNP Schema either. This will also allows group modifications without modifying the configured group owner already specified on the SharePoint group.
It requires changes to the provisioning engine, which has been implemented in [PnP Core PR #2020](https://github.com/SharePoint/PnP-Sites-Core/pull/2020)
