### PR TITLE
Added NoDefaultOrigins attribute for CDNs

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -5302,6 +5302,15 @@
       </xsd:annotation>
     </xsd:attribute>
 
+    <xsd:attribute name="NoDefaultOrigins" type="xsd:boolean" use="optional" default="false">
+      <xsd:annotation>
+        <xsd:appinfo>Added with schema version 201901</xsd:appinfo>
+        <xsd:documentation xml:lang="en">
+          Defines whether the CDN should have default origins, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
   </xsd:complexType>
 
   <xsd:complexType name="Publishing">


### PR DESCRIPTION
Added `NoDefaultOrigins` attribute to CDN. It will be false by default.

After this, we will have an option to specify whether to allow default origins or not as below:

```
<pnp:ContentDeliveryNetwork>
      <pnp:Public Enabled="true" NoDefaultOrigins="true">
     </pnp:Public>
</pnp:ContentDeliveryNetwork>
```
It is based on [Set-SPOTenantCdnEnabled](https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/set-spotenantcdnenabled?view=sharepoint-ps) commandlet. Once this is merged, would like to pick up the implementation task in the engine :) 