### PR TITLE
Part of the Fix for Issues #2320 and #2254 logged on PnP-Sites-Core Github

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2019-03.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2019-03.xsd
@@ -4837,7 +4837,8 @@
           <xsd:enumeration value="MarkDown" />
           <xsd:enumeration value="MicrosoftForms" />
           <xsd:enumeration value="MyDocuments" />
-          <xsd:enumeration value="NewsFeed" />
+          <xsd:enumeration value="News" />
+		  <xsd:enumeration value="NewsFeed" />
           <xsd:enumeration value="NewsReel" />
           <xsd:enumeration value="PageFields" />
           <xsd:enumeration value="PageTitle" />


### PR DESCRIPTION
In order for the schema to support a new WebPartType "News" as part of my fixes for in PnP-Sites-Core I need a new enum value "News".

This is a fix for a new version of the "NewsReel" (Guid: a5df8fdf-b508-4b66-98a6-d83bc2597f63) that is now called "News" (Guid 8c88f208-6c77-4bdb-86a0-0c47b4316588).  Before I could make this change I worked with Microsoft support / product to ensure that both controls from the API (_api/web/GetClientSideWebParts) as it was not originally.

Related PnP-Sites-Core issues:

https://github.com/SharePoint/PnP-Sites-Core/issues/2320
https://github.com/SharePoint/PnP-Sites-Core/issues/2254