### PR TITLE
Updated samples for "AppPackageId" token

### DIFF
--- a/Samples/ProvisioningSchema-2018-07-FullSample-01.xml
+++ b/Samples/ProvisioningSchema-2018-07-FullSample-01.xml
@@ -842,7 +842,7 @@
         </pnp:AppCatalog>
         <pnp:Apps>
           <pnp:App AppId="d0816f0a-fda4-4a98-8e61-1bbe1f2b5b27" Action="Install" SyncMode="Synchronously" />
-          <pnp:App AppId="{AppPackageId:spfx-discuss-now.sppkg}" Action="Update" SyncMode="Asynchronously" />
+          <pnp:App AppId="{AppPackageId:spfx-discuss-now}" Action="Update" SyncMode="Asynchronously" />
           <pnp:App AppId="9672a07b-c111-4a12-bb5b-8d43c2ddd256" Action="Uninstall" />
         </pnp:Apps>
       </pnp:ApplicationLifecycleManagement>

--- a/Samples/ProvisioningSchema-2019-03-FullSample-01.xml
+++ b/Samples/ProvisioningSchema-2019-03-FullSample-01.xml
@@ -878,7 +878,7 @@
         </pnp:AppCatalog>
         <pnp:Apps>
           <pnp:App AppId="d0816f0a-fda4-4a98-8e61-1bbe1f2b5b27" Action="Install" SyncMode="Synchronously" />
-          <pnp:App AppId="{AppPackageId:spfx-discuss-now.sppkg}" Action="Update" SyncMode="Asynchronously" />
+          <pnp:App AppId="{AppPackageId:spfx-discuss-now}" Action="Update" SyncMode="Asynchronously" />
           <pnp:App AppId="9672a07b-c111-4a12-bb5b-8d43c2ddd256" Action="Uninstall" />
         </pnp:Apps>
       </pnp:ApplicationLifecycleManagement>


### PR DESCRIPTION
Pull request related to issue: https://github.com/SharePoint/PnP-Provisioning-Schema/issues/384

Removed the extension of the "AppPackageId" token from 2018-07 and 2019-03 samples.