### PR TITLE
Missing Properties on pnp:Folder in Order to support DocumentSet

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2019-03.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-2019-03.xsd
@@ -3066,6 +3066,18 @@
 
   </xsd:complexType>
 
+  <xsd:complexType name="FolderProperties">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A collection of Folder Properties.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Property" type="pnp:StringDictionaryItem"
+                    minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
   <xsd:complexType name="Folder">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
@@ -3115,6 +3127,13 @@
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>
+      <xsd:element name="Properties" type="pnp:FolderProperties" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            The Folder Properties, optional collection of elements.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
     </xsd:sequence>
 
     <xsd:attribute name="Name" type="xsd:string" use="required">
@@ -3124,7 +3143,14 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-
+    
+    <xsd:attribute name="ContentTypeID" type="pnp:ReplaceableString" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Defines the Content Type ID for the Folder in order to support OneNote, optional attribute.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="BaseFieldValue">
@@ -4999,7 +5025,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-
+    
     <xsd:attribute name="Folder" type="xsd:string" use="required">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">

--- a/ProvisioningSchema-2015-05.md
+++ b/ProvisioningSchema-2015-05.md
@@ -1,20 +1,20 @@
 ﻿
-#PnP Provisioning Schema
+# PnP Provisioning Schema
 ----------
 *Topic automatically generated on 8/24/2015*
 
-##Namespace
+## Namespace
 The namespace of the PnP Provisioning Schema is:
 
 http://schemas.dev.office.com/PnP/2015/05/ProvisioningSchema
 
 All the elements have to be declared with that namespace reference.
 
-##Root Elements
+## Root Elements
 Here follows the list of root elements available in the PnP Provisioning Schema.
   
 <a name="provisioning"></a>
-###Provisioning
+### Provisioning
 
 
 ```xml
@@ -38,7 +38,7 @@ Templates|[Templates](#templates)|An optional section made of provisioning templ
 Sequence|[Sequence](#sequence)|An optional section made of provisioning sequences, which can include Sites, Site Collections, Taxonomies, Provisioning Templates, etc.
 ImportSequence|[ImportSequence](#importsequence)|Imports sequences from an external file. All current properties should be sent to that file.
 <a name="provisioningtemplate"></a>
-###ProvisioningTemplate
+### ProvisioningTemplate
 Represents the root element of the SharePoint Provisioning Template
 
 ```xml
@@ -91,10 +91,10 @@ ID|xsd:ID|The ID of the Provisioning Template, required attribute
 Version|xsd:decimal|The Version of the Provisioning Template, required attribute
 
 
-##Child Elements and Complex Types
+## Child Elements and Complex Types
 Here follows the list of all the other child elements and complex types that can be used in the PnP Provisioning Schema.
 <a name="preferences"></a>
-###Preferences
+### Preferences
 General settings for a Provisioning file.
 
 ```xml
@@ -123,7 +123,7 @@ Version|xsd:string|Optional version number.
 Author|xsd:string|Optional Author name
 Generator|xsd:string|Optional Name of tool generating this file
 <a name="parameters"></a>
-###Parameters
+### Parameters
 Definition of parameters that can be used as replacement within templates and provisioning objects.
 
 ```xml
@@ -140,7 +140,7 @@ Element|Type|Description
 -------|----|-----------
 Parameter|[Parameter](#parameter)|A Parameter that can be used as a replacement within templates and provisioning objects.
 <a name="templates"></a>
-###Templates
+### Templates
 SharePoint Templates, which can be inline or references to external files
 
 ```xml
@@ -169,7 +169,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:ID|A unique identifier of the Templates collection, optional attribute
 <a name="propertybagentries"></a>
-###PropertyBagEntries
+### PropertyBagEntries
 The Property Bag entries of the Provisioning Template, optional collection of elements
 
 ```xml
@@ -186,7 +186,7 @@ Element|Type|Description
 -------|----|-----------
 PropertyBagEntry|[PropertyBagEntry](#propertybagentry)|
 <a name="security"></a>
-###Security
+### Security
 The Security Groups Members of the Provisioning Template, optional collection of elements
 
 ```xml
@@ -209,7 +209,7 @@ AdditionalOwners|[UsersList](#userslist)|List of additional Owners for the Site,
 AdditionalMembers|[UsersList](#userslist)|List of additional Members for the Site, optional collection of elements
 AdditionalVisitors|[UsersList](#userslist)|List of additional Visitors for the Site, optional collection of elements
 <a name="sitefields"></a>
-###SiteFields
+### SiteFields
 The Site Columns of the Provisioning Template, optional element
 
 ```xml
@@ -219,7 +219,7 @@ The Site Columns of the Provisioning Template, optional element
 ```
 
 <a name="contenttypes"></a>
-###ContentTypes
+### ContentTypes
 The Content Types of the Provisioning Template, optional element
 
 ```xml
@@ -236,7 +236,7 @@ Element|Type|Description
 -------|----|-----------
 ContentType|[ContentType](#contenttype)|
 <a name="lists"></a>
-###Lists
+### Lists
 The Lists instances of the Provisioning Template, optional element
 
 ```xml
@@ -253,7 +253,7 @@ Element|Type|Description
 -------|----|-----------
 ListInstance|[ListInstance](#listinstance)|
 <a name="features"></a>
-###Features
+### Features
 The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements
 
 ```xml
@@ -272,7 +272,7 @@ Element|Type|Description
 SiteFeatures|[FeaturesList](#featureslist)|The Site Features to activate or deactivate while applying the Provisioning Template, optional collection of elements
 WebFeatures|[FeaturesList](#featureslist)|The Web Features to activate or deactivate while applying the Provisioning Template, optional collection of elements
 <a name="customactions"></a>
-###CustomActions
+### CustomActions
 The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element
 
 ```xml
@@ -291,7 +291,7 @@ Element|Type|Description
 SiteCustomActions|[CustomActionsList](#customactionslist)|The Site Custom Actions to provision while applying the Provisioning Template, optional element
 WebCustomActions|[CustomActionsList](#customactionslist)|The Web Custom Actions to provision while applying the Provisioning Template, optional element
 <a name="files"></a>
-###Files
+### Files
 The Files to provision into the target Site through the Provisioning Template, optional element
 
 ```xml
@@ -308,7 +308,7 @@ Element|Type|Description
 -------|----|-----------
 File|[File](#file)|
 <a name="pages"></a>
-###Pages
+### Pages
 The Pages to provision into the target Site through the Provisioning Template, optional element
 
 ```xml
@@ -325,7 +325,7 @@ Element|Type|Description
 -------|----|-----------
 Page|[Page](#page)|
 <a name="termgroups"></a>
-###TermGroups
+### TermGroups
 The TermGroups element allows provisioning one or more TermGroups into the target Site, optional element
 
 ```xml
@@ -342,7 +342,7 @@ Element|Type|Description
 -------|----|-----------
 TermGroup|[TermGroup](#termgroup)|The TermGroup element to provision into the target Site through the Provisioning Template, optional element
 <a name="providers"></a>
-###Providers
+### Providers
 The Extensiblity Providers to invoke while applying the Provisioning Template, optional collection of elements
 
 ```xml
@@ -359,7 +359,7 @@ Element|Type|Description
 -------|----|-----------
 Provider|[Provider](#provider)|
 <a name="propertybagentry"></a>
-###PropertyBagEntry
+### PropertyBagEntry
 A property bag entry
 
 ```xml
@@ -376,7 +376,7 @@ Attibute|Type|Description
 --------|----|-----------
 Indexed|xsd:boolean|
 <a name="stringdictionaryitem"></a>
-###StringDictionaryItem
+### StringDictionaryItem
 Defines a StringDictionary element
 
 ```xml
@@ -395,7 +395,7 @@ Attibute|Type|Description
 Key|xsd:string|The Key of the property to store in the StringDictionary, required attribute
 Value|xsd:string|The Value of the property to store in the StringDictionary, required attribute
 <a name="userslist"></a>
-###UsersList
+### UsersList
 List of Users for the Site Security, collection of elements
 
 ```xml
@@ -412,7 +412,7 @@ Element|Type|Description
 -------|----|-----------
 User|[User](#user)|
 <a name="user"></a>
-###User
+### User
 The base abstract type for a User element
 
 ```xml
@@ -429,7 +429,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the User, required attribute
 <a name="listinstance"></a>
-###ListInstance
+### ListInstance
 Defines a ListInstance element
 
 ```xml
@@ -496,7 +496,7 @@ Hidden|xsd:boolean|The Hidden flag for the List Instance, optional attribute
 EnableAttachments|xsd:boolean|The EnableAttachments flag for the List Instance, optional attribute
 EnableFolderCreation|xsd:boolean|The EnableFolderCreation flag for the List Instance, optional attribute
 <a name="contenttypebindings"></a>
-###ContentTypeBindings
+### ContentTypeBindings
 The ContentTypeBindings entries of the List Instance, optional collection of elements
 
 ```xml
@@ -513,7 +513,7 @@ Element|Type|Description
 -------|----|-----------
 ContentTypeBinding|[ContentTypeBinding](#contenttypebinding)|
 <a name="views"></a>
-###Views
+### Views
 The Views entries of the List Instance, optional collection of elements
 
 ```xml
@@ -531,7 +531,7 @@ Attibute|Type|Description
 --------|----|-----------
 RemoveExistingViews|xsd:boolean|A flag to declare if the existing views of the List Instance have to be removed, befire adding the custom views, optional attribute
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields entries of the List Instance, optional collection of elements
 
 ```xml
@@ -541,7 +541,7 @@ The Fields entries of the List Instance, optional collection of elements
 ```
 
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements
 
 ```xml
@@ -558,7 +558,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ListInstanceFieldRef](#listinstancefieldref)|
 <a name="datarows"></a>
-###DataRows
+### DataRows
 
 
 ```xml
@@ -575,7 +575,7 @@ Element|Type|Description
 -------|----|-----------
 DataRow|[DataRow](#datarow)|
 <a name="datavalue"></a>
-###DataValue
+### DataValue
 The DataValue of a single field of a row to insert into a target ListInstance
 
 ```xml
@@ -592,7 +592,7 @@ Attibute|Type|Description
 --------|----|-----------
 FieldName|xsd:string|
 <a name="contenttype"></a>
-###ContentType
+### ContentType
 Defines a content type
 
 ```xml
@@ -633,7 +633,7 @@ Sealed|xsd:boolean|Optional Boolean. True to prevent changes to this content typ
 ReadOnly|xsd:boolean|Optional Boolean. TRUE to specify that the content type cannot be edited without explicitly removing the read-only setting. This can be done either in the user interface or in code.
 Overwrite|xsd:boolean|Optional Boolean. TRUE to overwrite an existing content type with the same ID.
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements
 
 ```xml
@@ -650,7 +650,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ContentTypeFieldRef](#contenttypefieldref)|
 <a name="documenttemplate"></a>
-###DocumentTemplate
+### DocumentTemplate
 Specifies the document template for the content type. This is the file which SharePoint Foundation opens as a template when a user requests a new item of this content type.
 
 ```xml
@@ -667,7 +667,7 @@ Attibute|Type|Description
 --------|----|-----------
 TargetName|xsd:string|The value of the content type ID, required attribute
 <a name="contenttypebinding"></a>
-###ContentTypeBinding
+### ContentTypeBinding
 Defines the binding between a ListInstance and a ContentType
 
 ```xml
@@ -686,7 +686,7 @@ Attibute|Type|Description
 ContentTypeID|ContentTypeId|The value of the ContentTypeID to bind, required attribute
 Default|xsd:boolean|Declares if the Content Type should be the default Content Type in the list or library, optional attribute
 <a name="featureslist"></a>
-###FeaturesList
+### FeaturesList
 Defines a collection of elements of type Feature
 
 ```xml
@@ -703,7 +703,7 @@ Element|Type|Description
 -------|----|-----------
 Feature|[Feature](#feature)|
 <a name="feature"></a>
-###Feature
+### Feature
 Defines a single Site or Web Feature, which will be activated or deactivated while applying the Provisioning Template
 
 ```xml
@@ -724,7 +724,7 @@ ID|GUID|The unique ID of the Feature, required attribute
 Deactivate|xsd:boolean|Defines if the feature has to be deactivated or activated while applying the Provisioning Template, optional attribute
 Description|xsd:string|The Description of the feature, optional attribute
 <a name="listinstancefieldref"></a>
-###ListInstanceFieldRef
+### ListInstanceFieldRef
 Defines the binding between a ListInstance and a Field
 
 ```xml
@@ -749,7 +749,7 @@ Required|xsd:boolean|The Required flag for the field to bind, optional attribute
 Hidden|xsd:boolean|The Hidden flag for the field to bind, optional attribute
 DisplayName|xsd:string|The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute
 <a name="contenttypefieldref"></a>
-###ContentTypeFieldRef
+### ContentTypeFieldRef
 Defines the binding between a ContentType and a Field
 
 ```xml
@@ -772,7 +772,7 @@ Name|xsd:string|The name of the field used in the field reference. This is for r
 Required|xsd:boolean|The Required flag for the field to bind, optional attribute
 Hidden|xsd:boolean|The Hidden flag for the field to bind, optional attribute
 <a name="customactionslist"></a>
-###CustomActionsList
+### CustomActionsList
 Defines a collection of elements of type CustomAction
 
 ```xml
@@ -789,7 +789,7 @@ Element|Type|Description
 -------|----|-----------
 CustomAction|[CustomAction](#customaction)|
 <a name="customaction"></a>
-###CustomAction
+### CustomAction
 Defines a Custom Action, which will be provisioned while applying the Provisioning Template
 
 ```xml
@@ -836,7 +836,7 @@ ScriptBlock|xsd:string|The ScriptBlock of the CustomAction, optional attribute
 ImageUrl|xsd:string|The ImageUrl of the CustomAction, optional attribute
 ScriptSrc|xsd:string|The ScriptSrc of the CustomAction, optional attribute
 <a name="commanduiextension"></a>
-###CommandUIExtension
+### CommandUIExtension
 Defines the Custom UI Extension XML, optional element.
 
 ```xml
@@ -846,7 +846,7 @@ Defines the Custom UI Extension XML, optional element.
 ```
 
 <a name="fileproperties"></a>
-###FileProperties
+### FileProperties
 A collection of File Properties
 
 ```xml
@@ -863,7 +863,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|
 <a name="file"></a>
-###File
+### File
 Defines a File element, to describe a file that will be provisioned into the target Site
 
 ```xml
@@ -894,7 +894,7 @@ Src|xsd:string|The Src of the File, required attribute
 Folder|xsd:string|The TargetFolder of the File, required attribute
 Overwrite|xsd:boolean|The Overwrite flag for the File, optional attribute
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements
 
 ```xml
@@ -911,7 +911,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WebPartPageWebPart](#webpartpagewebpart)|
 <a name="page"></a>
-###Page
+### Page
 Defines a Page element, to describe a page that will be provisioned into the target Site. Because of the Layout attribute, the assumption is made that you're referring/creating a WikiPage.
 
 ```xml
@@ -942,7 +942,7 @@ Overwrite|xsd:boolean|Optional: if set, overwrites an existing page in the case 
 Layout|WikiPageLayout|Required: Defines the layout of the wikipage
 WelcomePage|xsd:boolean|Defines whether the page should be set as Welcomepage of the web rootfolder
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements
 
 ```xml
@@ -959,7 +959,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WikiPageWebPart](#wikipagewebpart)|
 <a name="wikipagewebpart"></a>
-###WikiPageWebPart
+### WikiPageWebPart
 Defines a WebPart to be added to a WikiPage
 
 ```xml
@@ -988,7 +988,7 @@ Title|xsd:string|Required: Defines the title of the WebPart
 Row|xsd:int|Required: Defines the row to add the WebPart to
 Column|xsd:int|Required: Defines the column to add the WebPart to
 <a name="webpartpagewebpart"></a>
-###WebPartPageWebPart
+### WebPartPageWebPart
 Defines a webpart to be added to a WebPart Page
 
 ```xml
@@ -1017,7 +1017,7 @@ Title|xsd:string|Required: Defines the title of the WebPart
 Zone|xsd:string|Required: defines the zone of a WebPart Page to add the webpart to
 Order|xsd:int|Required: defines the index of the WebPart in the zone
 <a name="composedlook"></a>
-###ComposedLook
+### ComposedLook
 Defines a ComposedLook element
 
 ```xml
@@ -1048,7 +1048,7 @@ SiteLogo|xsd:string|The SiteLogo of the ComposedLook, optional attribute
 AlternateCSS|xsd:string|The AlternateCSS of the ComposedLook, optional attribute
 Version|xsd:int|The Version of the ComposedLook, optional attribute
 <a name="provider"></a>
-###Provider
+### Provider
 Defines an Extensibility Provider
 
 ```xml
@@ -1075,7 +1075,7 @@ Attibute|Type|Description
 Enabled|xsd:boolean|Defines whether the Extensibility Provider is enabled or not, optional attribute
 HandlerType|xsd:string|The type of the handler. It can be a FQN of a .NET type, the URL of a node.js file, or whatever else, required attribute
 <a name="configuration"></a>
-###Configuration
+### Configuration
 Defines an optional configuration section for the Extensibility Provider. The configuration section can be any XML
 
 ```xml
@@ -1085,7 +1085,7 @@ Defines an optional configuration section for the Extensibility Provider. The co
 ```
 
 <a name="provisioningtemplatefile"></a>
-###ProvisioningTemplateFile
+### ProvisioningTemplateFile
 An element that references an external file.
 
 ```xml
@@ -1104,7 +1104,7 @@ Attibute|Type|Description
 File|xsd:string|Absolute or relative path to the file.
 ID|xsd:ID|ID of the referenced template
 <a name="provisioningtemplatereference"></a>
-###ProvisioningTemplateReference
+### ProvisioningTemplateReference
 An element that references an external file.
 
 ```xml
@@ -1121,7 +1121,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:IDREF|ID of the referenced template
 <a name="sequence"></a>
-###Sequence
+### Sequence
 Each Provisioning file is split into a set of Sequence elements. The Sequence element groups the artefacts to be provisioned into groups. The Sequences must be evaluated by the provisioning engine in the order in which they appear.
 
 ```xml
@@ -1154,7 +1154,7 @@ Attibute|Type|Description
 SequenceType||Instructions to the Provisioning engine on how the Containers within the Sequence can be provisioned.
 ID|xsd:ID|A unique identifier of the Sequence
 <a name="sitecollection"></a>
-###SiteCollection
+### SiteCollection
 Defines a SiteCollection that will be created into the target tenant/farm
 
 ```xml
@@ -1179,7 +1179,7 @@ Attibute|Type|Description
 --------|----|-----------
 Url|ReplaceableString|Absolute Url to the site
 <a name="site"></a>
-###Site
+### Site
 Defines a Site that will be created into a target Site Collection
 
 ```xml
@@ -1206,7 +1206,7 @@ Attibute|Type|Description
 UseSamePermissionsAsParentSite|xsd:boolean|
 Url|ReplaceableString|Relative Url to the site
 <a name="termstore"></a>
-###TermStore
+### TermStore
 A TermStore to use for provisioning of TermGroups
 
 ```xml
@@ -1231,7 +1231,7 @@ Attibute|Type|Description
 --------|----|-----------
 Scope||The scope of the term store.
 <a name="termgroup"></a>
-###TermGroup
+### TermGroup
 A TermGroup to use for provisioning of TermSets and Terms
 
 ```xml
@@ -1252,7 +1252,7 @@ Description|xsd:string|
 Name|xsd:string|
 ID|GUID|
 <a name="termsetitem"></a>
-###TermSetItem
+### TermSetItem
 Base type for TermSets and Terms
 
 ```xml
@@ -1273,7 +1273,7 @@ Owner|xsd:string|
 Description|xsd:string|
 IsAvailableForTagging|xsd:boolean|
 <a name="termset"></a>
-###TermSet
+### TermSet
 A TermSet to provision
 
 ```xml
@@ -1292,7 +1292,7 @@ Attibute|Type|Description
 Language|xsd:int|
 IsOpenForTermCreation|xsd:boolean|
 <a name="term"></a>
-###Term
+### Term
 A Term to provision into a TermSet or a hyerarchical Term
 
 ```xml
@@ -1311,7 +1311,7 @@ Attibute|Type|Description
 Language|xsd:int|
 CustomSortOrder|xsd:int|
 <a name="taxonomyitemproperties"></a>
-###TaxonomyItemProperties
+### TaxonomyItemProperties
 A collection of Term Properties
 
 ```xml
@@ -1328,7 +1328,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|
 <a name="termlabels"></a>
-###TermLabels
+### TermLabels
 A collection of Term Labels, in order to support multi-language terms
 
 ```xml
@@ -1345,7 +1345,7 @@ Element|Type|Description
 -------|----|-----------
 Label|[Label](#label)|
 <a name="label"></a>
-###Label
+### Label
 
 
 ```xml
@@ -1366,7 +1366,7 @@ Language|xsd:int|
 Value|xsd:string|
 IsDefaultForLanguage|xsd:boolean|
 <a name="termsets"></a>
-###TermSets
+### TermSets
 A collection of TermSets to provision
 
 ```xml
@@ -1383,7 +1383,7 @@ Element|Type|Description
 -------|----|-----------
 TermSet|[TermSet](#termset)|
 <a name="extensions"></a>
-###Extensions
+### Extensions
 Extensions are custom XML elements and instructions that can be extensions of this default schema or vendor or engine specific extensions.
 
 ```xml
@@ -1393,7 +1393,7 @@ Extensions are custom XML elements and instructions that can be extensions of th
 ```
 
 <a name="importsequence"></a>
-###ImportSequence
+### ImportSequence
 Imports sequences from an external file. All current properties should be sent to that file.
 
 ```xml

--- a/ProvisioningSchema-2015-08.md
+++ b/ProvisioningSchema-2015-08.md
@@ -1,20 +1,20 @@
 ﻿
-#PnP Provisioning Schema
+# PnP Provisioning Schema
 ----------
 *Topic automatically generated on 9/20/2015*
 
-##Namespace
+## Namespace
 The namespace of the PnP Provisioning Schema is:
 
 http://schemas.dev.office.com/PnP/2015/08/ProvisioningSchema
 
 All the elements have to be declared with that namespace reference.
 
-##Root Elements
+## Root Elements
 Here follows the list of root elements available in the PnP Provisioning Schema.
   
 <a name="provisioning"></a>
-###Provisioning
+### Provisioning
 
 
 ```xml
@@ -38,7 +38,7 @@ Templates|[Templates](#templates)|An optional section made of provisioning templ
 Sequence|[Sequence](#sequence)|An optional section made of provisioning sequences, which can include Sites, Site Collections, Taxonomies, Provisioning Templates, etc.
 ImportSequence|[ImportSequence](#importsequence)|Imports sequences from an external file. All current properties should be sent to that file.
 <a name="provisioningtemplate"></a>
-###ProvisioningTemplate
+### ProvisioningTemplate
 Represents the root element of the SharePoint Provisioning Template.
 
 ```xml
@@ -113,10 +113,10 @@ DisplayName|xsd:string|The Display Name of the Provisioning Template, optional a
 Description|xsd:string|The Description of the Provisioning Template, optional attribute.
 
 
-##Child Elements and Complex Types
+## Child Elements and Complex Types
 Here follows the list of all the other child elements and complex types that can be used in the PnP Provisioning Schema.
 <a name="preferences"></a>
-###Preferences
+### Preferences
 General settings for a Provisioning file.
 
 ```xml
@@ -145,7 +145,7 @@ Version|xsd:string|Provisioning File Version number, optional attribute.
 Author|xsd:string|Provisioning File Author name, optional attribute.
 Generator|xsd:string|Name of the tool generating this Provisioning File, optional attribute.
 <a name="parameters"></a>
-###Parameters
+### Parameters
 Definition of parameters that can be used as replacement within templates and provisioning objects.
 
 ```xml
@@ -162,7 +162,7 @@ Element|Type|Description
 -------|----|-----------
 Parameter|[Parameter](#parameter)|A Parameter that can be used as a replacement within templates and provisioning objects.
 <a name="templates"></a>
-###Templates
+### Templates
 SharePoint Templates, which can be inline or references to external files.
 
 ```xml
@@ -191,7 +191,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:ID|A unique identifier of the Templates collection, optional attribute.
 <a name="sitefields"></a>
-###SiteFields
+### SiteFields
 The Site Columns of the Provisioning Template, optional element.
 
 ```xml
@@ -201,7 +201,7 @@ The Site Columns of the Provisioning Template, optional element.
 ```
 
 <a name="contenttypes"></a>
-###ContentTypes
+### ContentTypes
 The Content Types of the Provisioning Template, optional element.
 
 ```xml
@@ -218,7 +218,7 @@ Element|Type|Description
 -------|----|-----------
 ContentType|[ContentType](#contenttype)|
 <a name="lists"></a>
-###Lists
+### Lists
 The Lists instances of the Provisioning Template, optional element.
 
 ```xml
@@ -235,7 +235,7 @@ Element|Type|Description
 -------|----|-----------
 ListInstance|[ListInstance](#listinstance)|
 <a name="files"></a>
-###Files
+### Files
 The Files to provision into the target Site through the Provisioning Template, optional element.
 
 ```xml
@@ -252,7 +252,7 @@ Element|Type|Description
 -------|----|-----------
 File|[File](#file)|
 <a name="termgroups"></a>
-###TermGroups
+### TermGroups
 The TermGroups element allows provisioning one or more TermGroups into the target Site, optional element.
 
 ```xml
@@ -269,7 +269,7 @@ Element|Type|Description
 -------|----|-----------
 TermGroup|[TermGroup](#termgroup)|The TermGroup element to provision into the target Site through the Provisioning Template, optional element.
 <a name="searchsettings"></a>
-###SearchSettings
+### SearchSettings
 The Search Settings for the Provisioning Template, optional element.
 
 ```xml
@@ -279,7 +279,7 @@ The Search Settings for the Provisioning Template, optional element.
 ```
 
 <a name="providers"></a>
-###Providers
+### Providers
 The Extensiblity Providers to invoke while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -296,7 +296,7 @@ Element|Type|Description
 -------|----|-----------
 Provider|[Provider](#provider)|
 <a name="provisioningtemplateproperties"></a>
-###ProvisioningTemplateProperties
+### ProvisioningTemplateProperties
 A set of custom Properties for the Provisioning Template.
 
 ```xml
@@ -313,7 +313,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A custom Property for the Provisioning Template, collection of elements.
 <a name="regionalsettings"></a>
-###RegionalSettings
+### RegionalSettings
 Defines the Regional Settings for a site.
 
 ```xml
@@ -354,7 +354,7 @@ WorkDayEndHour|WorkHour|The the default hour at which the work day ends on the c
 WorkDays|xsd:int|The work days of Web site calendars, optinal attribute.
 WorkDayStartHour|WorkHour|The the default hour at which the work day starts on the calendar that is in use on the server, optinal attribute.
 <a name="supporteduilanguages"></a>
-###SupportedUILanguages
+### SupportedUILanguages
 Defines the Supported UI Languages for a site.
 
 ```xml
@@ -371,7 +371,7 @@ Element|Type|Description
 -------|----|-----------
 SupportedUILanguage|[SupportedUILanguage](#supporteduilanguage)|Defines a single Supported UI Language for a site.
 <a name="supporteduilanguage"></a>
-###SupportedUILanguage
+### SupportedUILanguage
 Defines a single Supported UI Language for a site.
 
 ```xml
@@ -388,7 +388,7 @@ Attibute|Type|Description
 --------|----|-----------
 LCID|xsd:int|The Locale ID of a Supported UI Language, required attribute.
 <a name="auditsettings"></a>
-###AuditSettings
+### AuditSettings
 The Audit Settings for the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -415,7 +415,7 @@ Attibute|Type|Description
 AuditLogTrimmingRetention|xsd:int|The Audit Log Trimming Retention for Audits, optional attribute.
 TrimAuditLog|xsd:boolean|A flag to enable Audit Log Trimming, optional attribute.
 <a name="audit"></a>
-###Audit
+### Audit
 A single Audit setting defined by an AuditFlag.
 
 ```xml
@@ -432,7 +432,7 @@ Attibute|Type|Description
 --------|----|-----------
 AuditFlag||An Audit Flag for a single Audit setting, required attribute.
 <a name="propertybagentries"></a>
-###PropertyBagEntries
+### PropertyBagEntries
 The Property Bag entries of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -449,7 +449,7 @@ Element|Type|Description
 -------|----|-----------
 PropertyBagEntry|[PropertyBagEntry](#propertybagentry)|
 <a name="security"></a>
-###Security
+### Security
 The Security configurations of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -476,7 +476,7 @@ AdditionalVisitors|[UsersList](#userslist)|List of additional Visitors for the S
 SiteGroups|[SiteGroups](#sitegroups)|List of additional Groups for the Site, optional collection of elements.
 Permissions|[Permissions](#permissions)|
 <a name="permissions"></a>
-###Permissions
+### Permissions
 
 
 ```xml
@@ -495,7 +495,7 @@ Element|Type|Description
 RoleDefinitions|[RoleDefinitions](#roledefinitions)|List of Role Definitions for the Site, optional collection of elements.
 RoleAssignments|[RoleAssignments](#roleassignments)|List of Role Assignments for the Site, optional collection of elements.
 <a name="features"></a>
-###Features
+### Features
 The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -514,7 +514,7 @@ Element|Type|Description
 SiteFeatures|[FeaturesList](#featureslist)|The Site Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 WebFeatures|[FeaturesList](#featureslist)|The Web Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 <a name="customactions"></a>
-###CustomActions
+### CustomActions
 The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element.
 
 ```xml
@@ -533,7 +533,7 @@ Element|Type|Description
 SiteCustomActions|[CustomActionsList](#customactionslist)|The Site Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 WebCustomActions|[CustomActionsList](#customactionslist)|The Web Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 <a name="pages"></a>
-###Pages
+### Pages
 The Pages to provision into the target Site through the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -558,7 +558,7 @@ Attibute|Type|Description
 --------|----|-----------
 WelcomePage|xsd:string|Defines the Welcome Page (Home Page) of the site to which the Provisioning Template is applied, optional attribute.
 <a name="propertybagentry"></a>
-###PropertyBagEntry
+### PropertyBagEntry
 The Property Bag Entry of the Provisioning Template.
 
 ```xml
@@ -577,7 +577,7 @@ Attibute|Type|Description
 Overwrite|xsd:boolean|Declares whether the Property Bag Entry has to overwrite an already existing entry, optional attribute.
 Indexed|xsd:boolean|Declares whether the Property Bag Entry has to be indexed, optional attribute.
 <a name="stringdictionaryitem"></a>
-###StringDictionaryItem
+### StringDictionaryItem
 Defines a StringDictionary element.
 
 ```xml
@@ -596,7 +596,7 @@ Attibute|Type|Description
 Key|xsd:string|The Key of the property to store in the StringDictionary, required attribute.
 Value|xsd:string|The Value of the property to store in the StringDictionary, required attribute.
 <a name="userslist"></a>
-###UsersList
+### UsersList
 List of Users for the Site Security, collection of elements.
 
 ```xml
@@ -613,7 +613,7 @@ Element|Type|Description
 -------|----|-----------
 User|[User](#user)|
 <a name="user"></a>
-###User
+### User
 The base type for a User element.
 
 ```xml
@@ -630,7 +630,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the User, required attribute.
 <a name="sitegroups"></a>
-###SiteGroups
+### SiteGroups
 List of Site Groups for the Site Security, collection of elements.
 
 ```xml
@@ -647,7 +647,7 @@ Element|Type|Description
 -------|----|-----------
 SiteGroup|[SiteGroup](#sitegroup)|
 <a name="sitegroup"></a>
-###SiteGroup
+### SiteGroup
 The base type for a Site Group element.
 
 ```xml
@@ -686,7 +686,7 @@ AutoAcceptRequestToJoinLeave|xsd:boolean|Defines whether to auto-accept requests
 OnlyAllowMembersViewMembership|xsd:boolean|Defines whether to allow members only to view the membership of the Site Group, optional attribute.
 RequestToJoinLeaveEmailSetting|xsd:string|Defines the email address used for membership requests to join or leave will be sent for the Site Group, optional attribute.
 <a name="roledefinitions"></a>
-###RoleDefinitions
+### RoleDefinitions
 List of Role Definitions for a target RoleAssignment, collection of elements.
 
 ```xml
@@ -703,7 +703,7 @@ Element|Type|Description
 -------|----|-----------
 RoleDefinition|[RoleDefinition](#roledefinition)|
 <a name="roledefinition"></a>
-###RoleDefinition
+### RoleDefinition
 
 
 ```xml
@@ -730,7 +730,7 @@ Attibute|Type|Description
 Name|xsd:string|Defines the Name of the Role Definition, required attribute.
 Description|xsd:string|Defines the Description of the Role Definition, optional attribute.
 <a name="permissions"></a>
-###Permissions
+### Permissions
 Defines the Permissions of the Role Definition, required element.
 
 ```xml
@@ -747,7 +747,7 @@ Element|Type|Description
 -------|----|-----------
 Permission|[Permission](#permission)|Defines a Permission for a Role Definition.
 <a name="roleassignments"></a>
-###RoleAssignments
+### RoleAssignments
 List of Role Assignments for a target Principal, collection of elements.
 
 ```xml
@@ -764,7 +764,7 @@ Element|Type|Description
 -------|----|-----------
 RoleAssignment|[RoleAssignment](#roleassignment)|
 <a name="roleassignment"></a>
-###RoleAssignment
+### RoleAssignment
 
 
 ```xml
@@ -783,7 +783,7 @@ Attibute|Type|Description
 Principal|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 RoleDefinition|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 <a name="objectsecurity"></a>
-###ObjectSecurity
+### ObjectSecurity
 Defines a set of Role Assignments for specific principals.
 
 ```xml
@@ -800,7 +800,7 @@ Element|Type|Description
 -------|----|-----------
 BreakRoleInheritance|[BreakRoleInheritance](#breakroleinheritance)|
 <a name="breakroleinheritance"></a>
-###BreakRoleInheritance
+### BreakRoleInheritance
 Declares a section of custom permissions, breaking role inheritance from parent.
 
 ```xml
@@ -827,7 +827,7 @@ Attibute|Type|Description
 CopyRoleAssignments|xsd:boolean|Defines whether to copy role assignments or not while breaking role inheritance, required attribute.
 ClearSubscopes|xsd:boolean|Defines whether to clear subscopes or not while breaking role inheritance, required attribute.
 <a name="listinstance"></a>
-###ListInstance
+### ListInstance
 Defines a ListInstance element
 
 ```xml
@@ -898,7 +898,7 @@ Hidden|xsd:boolean|The Hidden flag for the List Instance, optional attribute.
 EnableAttachments|xsd:boolean|The EnableAttachments flag for the List Instance, optional attribute.
 EnableFolderCreation|xsd:boolean|The EnableFolderCreation flag for the List Instance, optional attribute.
 <a name="contenttypebindings"></a>
-###ContentTypeBindings
+### ContentTypeBindings
 The ContentTypeBindings entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -915,7 +915,7 @@ Element|Type|Description
 -------|----|-----------
 ContentTypeBinding|[ContentTypeBinding](#contenttypebinding)|
 <a name="views"></a>
-###Views
+### Views
 The Views entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -933,7 +933,7 @@ Attibute|Type|Description
 --------|----|-----------
 RemoveExistingViews|xsd:boolean|A flag to declare if the existing views of the List Instance have to be removed, before adding the custom views, optional attribute.
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -943,7 +943,7 @@ The Fields entries of the List Instance, optional collection of elements.
 ```
 
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -960,7 +960,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ListInstanceFieldRef](#listinstancefieldref)|
 <a name="datarows"></a>
-###DataRows
+### DataRows
 Defines a collection of rows that will be added to the List Instance, optional element.
 
 ```xml
@@ -977,7 +977,7 @@ Element|Type|Description
 -------|----|-----------
 DataRow|[DataRow](#datarow)|
 <a name="fielddefaults"></a>
-###FieldDefaults
+### FieldDefaults
 Defines a list of default values for the Fields of the List Instance, optional collection of elements.
 
 ```xml
@@ -994,7 +994,7 @@ Element|Type|Description
 -------|----|-----------
 FieldDefault|[FieldDefault](#fielddefault)|Defines a default value for a Field of the List Instance.
 <a name="datavalue"></a>
-###DataValue
+### DataValue
 The DataValue of a single field of a row to insert into a target ListInstance.
 
 ```xml
@@ -1003,7 +1003,7 @@ The DataValue of a single field of a row to insert into a target ListInstance.
 ```
 
 <a name="fielddefault"></a>
-###FieldDefault
+### FieldDefault
 The FieldDefault of a single field of list or library for target ListInstance.
 
 ```xml
@@ -1012,7 +1012,7 @@ The FieldDefault of a single field of list or library for target ListInstance.
 ```
 
 <a name="contenttype"></a>
-###ContentType
+### ContentType
 Defines a Content Type.
 
 ```xml
@@ -1061,7 +1061,7 @@ NewFormUrl|xsd:string|Specifies the URL of a custom new form to use for list ite
 EditFormUrl|xsd:string|Specifies the URL of a custom edit form to use for list items that have been assigned the content type, optional attribute.
 DisplayFormUrl|xsd:string|Specifies the URL of a custom display form to use for list items that have been assigned the content type, optional attribute.
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1078,7 +1078,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ContentTypeFieldRef](#contenttypefieldref)|
 <a name="documenttemplate"></a>
-###DocumentTemplate
+### DocumentTemplate
 Specifies the document template for the content type. This is the file which SharePoint Foundation opens as a template when a user requests a new item of this content type.
 
 ```xml
@@ -1095,7 +1095,7 @@ Attibute|Type|Description
 --------|----|-----------
 TargetName|xsd:string|The value of the Content Type ID, required attribute.
 <a name="contenttypebinding"></a>
-###ContentTypeBinding
+### ContentTypeBinding
 Defines the binding between a ListInstance and a ContentType.
 
 ```xml
@@ -1114,7 +1114,7 @@ Attibute|Type|Description
 ContentTypeID|ContentTypeId|The value of the Content Type ID to bind, required attribute.
 Default|xsd:boolean|Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
 <a name="documentsettemplate"></a>
-###DocumentSetTemplate
+### DocumentSetTemplate
 Defines a DocumentSet Template for creating multiple DocumentSet instances.
 
 ```xml
@@ -1145,7 +1145,7 @@ Attibute|Type|Description
 --------|----|-----------
 WelcomePage|xsd:string|Defines the custom WelcomePage for the Document Set, optional attribute.
 <a name="allowedcontenttypes"></a>
-###AllowedContentTypes
+### AllowedContentTypes
 The list of allowed Content Types for the Document Set, optional element.
 
 ```xml
@@ -1162,7 +1162,7 @@ Element|Type|Description
 -------|----|-----------
 AllowedContentType|[AllowedContentType](#allowedcontenttype)|
 <a name="defaultdocuments"></a>
-###DefaultDocuments
+### DefaultDocuments
 The list of default Documents for the Document Set, optional element.
 
 ```xml
@@ -1179,7 +1179,7 @@ Element|Type|Description
 -------|----|-----------
 DefaultDocument|[DefaultDocument](#defaultdocument)|
 <a name="sharedfields"></a>
-###SharedFields
+### SharedFields
 The list of Shared Fields for the Document Set, optional element.
 
 ```xml
@@ -1196,7 +1196,7 @@ Element|Type|Description
 -------|----|-----------
 SharedField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="welcomepagefields"></a>
-###WelcomePageFields
+### WelcomePageFields
 The list of Welcome Page Fields for the Document Set, optional element.
 
 ```xml
@@ -1213,7 +1213,7 @@ Element|Type|Description
 -------|----|-----------
 WelcomePageField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="featureslist"></a>
-###FeaturesList
+### FeaturesList
 Defines a collection of elements of type Feature.
 
 ```xml
@@ -1230,7 +1230,7 @@ Element|Type|Description
 -------|----|-----------
 Feature|[Feature](#feature)|
 <a name="feature"></a>
-###Feature
+### Feature
 Defines a single Site or Web Feature, which will be activated or deactivated while applying the Provisioning Template.
 
 ```xml
@@ -1251,7 +1251,7 @@ ID|GUID|The unique ID of the Feature, required attribute.
 Deactivate|xsd:boolean|Defines if the feature has to be deactivated or activated while applying the Provisioning Template, optional attribute.
 Description|xsd:string|The Description of the feature, optional attribute.
 <a name="fieldrefbase"></a>
-###FieldRefBase
+### FieldRefBase
 
 
 ```xml
@@ -1268,7 +1268,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|GUID|The value of the field ID to bind, required attribute.
 <a name="fieldreffull"></a>
-###FieldRefFull
+### FieldRefFull
 
 
 ```xml
@@ -1277,7 +1277,7 @@ ID|GUID|The value of the field ID to bind, required attribute.
 ```
 
 <a name="listinstancefieldref"></a>
-###ListInstanceFieldRef
+### ListInstanceFieldRef
 Defines the binding between a ListInstance and a Field.
 
 ```xml
@@ -1294,7 +1294,7 @@ Attibute|Type|Description
 --------|----|-----------
 DisplayName|xsd:string|The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute.
 <a name="contenttypefieldref"></a>
-###ContentTypeFieldRef
+### ContentTypeFieldRef
 Defines the binding between a ContentType and a Field.
 
 ```xml
@@ -1303,7 +1303,7 @@ Defines the binding between a ContentType and a Field.
 ```
 
 <a name="documentsetfieldref"></a>
-###DocumentSetFieldRef
+### DocumentSetFieldRef
 Defines the binding between a Document Set and a Field.
 
 ```xml
@@ -1312,7 +1312,7 @@ Defines the binding between a Document Set and a Field.
 ```
 
 <a name="customactionslist"></a>
-###CustomActionsList
+### CustomActionsList
 Defines a collection of elements of type CustomAction.
 
 ```xml
@@ -1329,7 +1329,7 @@ Element|Type|Description
 -------|----|-----------
 CustomAction|[CustomAction](#customaction)|
 <a name="customaction"></a>
-###CustomAction
+### CustomAction
 Defines a Custom Action, which will be provisioned while applying the Provisioning Template.
 
 ```xml
@@ -1376,7 +1376,7 @@ ScriptBlock|xsd:string|The ScriptBlock of the CustomAction, optional attribute.
 ImageUrl|xsd:string|The ImageUrl of the CustomAction, optional attribute.
 ScriptSrc|xsd:string|The ScriptSrc of the CustomAction, optional attribute.
 <a name="commanduiextension"></a>
-###CommandUIExtension
+### CommandUIExtension
 Defines the Custom UI Extension XML, optional element.
 
 ```xml
@@ -1386,7 +1386,7 @@ Defines the Custom UI Extension XML, optional element.
 ```
 
 <a name="fileproperties"></a>
-###FileProperties
+### FileProperties
 A collection of File Properties.
 
 ```xml
@@ -1403,7 +1403,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|
 <a name="file"></a>
-###File
+### File
 Defines a File element, to describe a file that will be provisioned into the target Site.
 
 ```xml
@@ -1436,7 +1436,7 @@ Src|xsd:string|The Src of the File, required attribute.
 Folder|xsd:string|The TargetFolder of the File, required attribute.
 Overwrite|xsd:boolean|The Overwrite flag for the File, optional attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1453,7 +1453,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WebPartPageWebPart](#webpartpagewebpart)|
 <a name="page"></a>
-###Page
+### Page
 Defines a Page element, to describe a page that will be provisioned into the target Site. Because of the Layout attribute, the assumption is made that you're referring/creating a WikiPage.
 
 ```xml
@@ -1484,7 +1484,7 @@ Url|xsd:string|The server relative url of the page, supports tokens, required at
 Overwrite|xsd:boolean|If set, overwrites an existing page in the case of a wikipage, optional attribute.
 Layout|WikiPageLayout|Defines the layout of the wikipage, required attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1501,7 +1501,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WikiPageWebPart](#wikipagewebpart)|
 <a name="wikipagewebpart"></a>
-###WikiPageWebPart
+### WikiPageWebPart
 Defines a WebPart to be added to a WikiPage.
 
 ```xml
@@ -1530,7 +1530,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Row|xsd:int|Defines the row to add the WebPart to, required attribute.
 Column|xsd:int|Defines the column to add the WebPart to, required attribute.
 <a name="webpartpagewebpart"></a>
-###WebPartPageWebPart
+### WebPartPageWebPart
 Defines a webpart to be added to a WebPart Page.
 
 ```xml
@@ -1559,7 +1559,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Zone|xsd:string|Defines the zone of a WebPart Page to add the webpart to, required attribute.
 Order|xsd:int|Defines the index of the WebPart in the zone, required attribute.
 <a name="composedlook"></a>
-###ComposedLook
+### ComposedLook
 Defines a ComposedLook element.
 
 ```xml
@@ -1590,7 +1590,7 @@ SiteLogo|xsd:string|The SiteLogo of the ComposedLook, optional attribute.
 AlternateCSS|xsd:string|The AlternateCSS of the ComposedLook, optional attribute.
 Version|xsd:int|The Version of the ComposedLook, optional attribute.
 <a name="workflows"></a>
-###Workflows
+### Workflows
 Defines the Workflows to provision.
 
 ```xml
@@ -1609,7 +1609,7 @@ Element|Type|Description
 WorkflowDefinitions|[WorkflowDefinitions](#workflowdefinitions)|
 WorkflowSubscriptions|[WorkflowSubscriptions](#workflowsubscriptions)|
 <a name="workflowdefinitions"></a>
-###WorkflowDefinitions
+### WorkflowDefinitions
 Defines the Workflows Definitions to provision.
 
 ```xml
@@ -1626,7 +1626,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowDefinition|[WorkflowDefinition](#workflowdefinition)|
 <a name="workflowsubscriptions"></a>
-###WorkflowSubscriptions
+### WorkflowSubscriptions
 Defines the Workflows Subscriptions to provision.
 
 ```xml
@@ -1643,7 +1643,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowSubscription|[WorkflowSubscription](#workflowsubscription)|
 <a name="addins"></a>
-###AddIns
+### AddIns
 Defines the SharePoint Add-ins to provision, collection of elements.
 
 ```xml
@@ -1660,7 +1660,7 @@ Element|Type|Description
 -------|----|-----------
 Addin|[Addin](#addin)|
 <a name="addin"></a>
-###Addin
+### Addin
 
 
 ```xml
@@ -1679,7 +1679,7 @@ Attibute|Type|Description
 PackagePath|xsd:string|Defines the .app file of the SharePoint Add-in to provision, required attribute.
 Source||Defines the Source of the SharePoint Add-in to provision, required attribute.
 <a name="publishing"></a>
-###Publishing
+### Publishing
 Defines the Publishing configuration to provision.
 
 ```xml
@@ -1708,7 +1708,7 @@ Attibute|Type|Description
 --------|----|-----------
 AutoCheckRequirements||Defines how an engine should behave if the requirements for provisioning publishing capabilities are not satisfied by the target site, required attribute.
 <a name="designpackage"></a>
-###DesignPackage
+### DesignPackage
 Defines a Design Package to import into the current Publishing site, optional element.
 
 ```xml
@@ -1733,7 +1733,7 @@ MinorVersion|xsd:int|The Minor Version of the Design Package to import into the 
 PackageGuid|GUID|The ID of the Design Package to import into the current Publishing site, optional attribute.
 PackageName|xsd:string|The Name of the Design Package to import into the current Publishing site, required attribute.
 <a name="availablewebtemplates"></a>
-###AvailableWebTemplates
+### AvailableWebTemplates
 Defines the Available Web Templates for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -1750,7 +1750,7 @@ Element|Type|Description
 -------|----|-----------
 WebTemplate|[WebTemplate](#webtemplate)|Defines an available Web Template for the current Publishing site.
 <a name="pagelayouts"></a>
-###PageLayouts
+### PageLayouts
 Defines the Available Page Layouts for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -1775,7 +1775,7 @@ Attibute|Type|Description
 --------|----|-----------
 Default|xsd:string|Defines the URL of the Default Page Layout for the current Publishing site, if any. Optional attribute.
 <a name="provider"></a>
-###Provider
+### Provider
 Defines an Extensibility Provider.
 
 ```xml
@@ -1802,7 +1802,7 @@ Attibute|Type|Description
 Enabled|xsd:boolean|Defines whether the Extensibility Provider is enabled or not, optional attribute.
 HandlerType|xsd:string|The type of the handler. It can be a FQN of a .NET type, the URL of a node.js file, or whatever else, required attribute.
 <a name="configuration"></a>
-###Configuration
+### Configuration
 Defines an optional configuration section for the Extensibility Provider. The configuration section can be any XML.
 
 ```xml
@@ -1812,7 +1812,7 @@ Defines an optional configuration section for the Extensibility Provider. The co
 ```
 
 <a name="provisioningtemplatefile"></a>
-###ProvisioningTemplateFile
+### ProvisioningTemplateFile
 An element that references an external file.
 
 ```xml
@@ -1831,7 +1831,7 @@ Attibute|Type|Description
 File|xsd:string|Absolute or relative path to the file, required attribute.
 ID|xsd:ID|ID of the referenced template, required attribute.
 <a name="provisioningtemplatereference"></a>
-###ProvisioningTemplateReference
+### ProvisioningTemplateReference
 An element that references an external file.
 
 ```xml
@@ -1848,7 +1848,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:IDREF|ID of the referenced template, required attribute.
 <a name="sequence"></a>
-###Sequence
+### Sequence
 Each Provisioning file is split into a set of Sequence elements. The Sequence element groups the artefacts to be provisioned into groups. The Sequences must be evaluated by the provisioning engine in the order in which they appear.
 
 ```xml
@@ -1881,7 +1881,7 @@ Attibute|Type|Description
 SequenceType||Instructions to the Provisioning engine on how the Containers within the Sequence can be provisioned.
 ID|xsd:ID|A unique identifier of the Sequence, required attribute.
 <a name="sitecollection"></a>
-###SiteCollection
+### SiteCollection
 Defines a SiteCollection that will be created into the target tenant/farm.
 
 ```xml
@@ -1906,7 +1906,7 @@ Attibute|Type|Description
 --------|----|-----------
 Url|ReplaceableString|Absolute Url to the site, required attribute.
 <a name="site"></a>
-###Site
+### Site
 Defines a Site that will be created into a target Site Collection.
 
 ```xml
@@ -1933,7 +1933,7 @@ Attibute|Type|Description
 UseSamePermissionsAsParentSite|xsd:boolean|
 Url|ReplaceableString|Relative Url to the site, required attribute.
 <a name="termstore"></a>
-###TermStore
+### TermStore
 A TermStore to use for provisioning of TermGroups.
 
 ```xml
@@ -1958,7 +1958,7 @@ Attibute|Type|Description
 --------|----|-----------
 Scope||The scope of the term store, required attribute.
 <a name="termgroup"></a>
-###TermGroup
+### TermGroup
 A TermGroup to use for provisioning of TermSets and Terms.
 
 ```xml
@@ -1981,7 +1981,7 @@ SiteCollectionTermGroup|xsd:boolean|Declares if the TermGroup is the Site Collec
 Name|xsd:string|The Name of the Taxonomy Item, required attribute.
 ID|GUID|The ID of the Taxonomy Item, optional attribute.
 <a name="termsetitem"></a>
-###TermSetItem
+### TermSetItem
 Base type for TermSets and Terms
 
 ```xml
@@ -2002,7 +2002,7 @@ Owner|xsd:string|The Owner of the Term Set Item, optional attribute.
 Description|xsd:string|The Description of the Term Set Item, optional attribute.
 IsAvailableForTagging|xsd:boolean|Declares whether the Term Set Item is available for tagging, optional attribute.
 <a name="termset"></a>
-###TermSet
+### TermSet
 A TermSet to provision.
 
 ```xml
@@ -2021,7 +2021,7 @@ Attibute|Type|Description
 Language|xsd:int|The reference Language for the Term Set, optional attribute.
 IsOpenForTermCreation|xsd:boolean|Declares whether the Term Set is open for terms creation or not, optional attribute.
 <a name="term"></a>
-###Term
+### Term
 A Term to provision into a TermSet or a hyerarchical Term.
 
 ```xml
@@ -2040,7 +2040,7 @@ Attibute|Type|Description
 Language|xsd:int|The reference Language for the Term, optional attribute.
 CustomSortOrder|xsd:int|The Custom Sort Order for the Term, optional attribute.
 <a name="taxonomyitemproperties"></a>
-###TaxonomyItemProperties
+### TaxonomyItemProperties
 A collection of Term Properties.
 
 ```xml
@@ -2057,7 +2057,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A Term Property, collection of elements.
 <a name="termlabels"></a>
-###TermLabels
+### TermLabels
 A collection of Term Labels, in order to support multi-language terms.
 
 ```xml
@@ -2074,7 +2074,7 @@ Element|Type|Description
 -------|----|-----------
 Label|[Label](#label)|
 <a name="label"></a>
-###Label
+### Label
 
 
 ```xml
@@ -2095,7 +2095,7 @@ Language|xsd:int|The reference Language for the Term Label, required attribute.
 Value|xsd:string|The Value for the Term Label, required attribute.
 IsDefaultForLanguage|xsd:boolean|Declares whether the current Label is the default for the specific Language, optional attribute.
 <a name="termsets"></a>
-###TermSets
+### TermSets
 A collection of TermSets to provision.
 
 ```xml
@@ -2112,7 +2112,7 @@ Element|Type|Description
 -------|----|-----------
 TermSet|[TermSet](#termset)|A Term Set, optional collection of elements.
 <a name="extensions"></a>
-###Extensions
+### Extensions
 Extensions are custom XML elements and instructions that can be extensions of this default schema or vendor or engine specific extensions.
 
 ```xml
@@ -2122,7 +2122,7 @@ Extensions are custom XML elements and instructions that can be extensions of th
 ```
 
 <a name="importsequence"></a>
-###ImportSequence
+### ImportSequence
 Imports sequences from an external file. All current properties should be sent to that file.
 
 ```xml

--- a/ProvisioningSchema-2015-12.md
+++ b/ProvisioningSchema-2015-12.md
@@ -1,20 +1,20 @@
 ﻿
-#PnP Provisioning Schema
+# PnP Provisioning Schema
 ----------
 *Topic automatically generated on 04/02/2016*
 
-##Namespace
+## Namespace
 The namespace of the PnP Provisioning Schema is:
 
 http://schemas.dev.office.com/PnP/2015/12/ProvisioningSchema
 
 All the elements have to be declared with that namespace reference.
 
-##Root Elements
+## Root Elements
 Here follows the list of root elements available in the PnP Provisioning Schema.
   
 <a name="provisioning"></a>
-###Provisioning
+### Provisioning
 
 
 ```xml
@@ -40,7 +40,7 @@ Templates|[Templates](#templates)|An optional section made of provisioning templ
 Sequence|[Sequence](#sequence)|An optional section made of provisioning sequences, which can include Sites, Site Collections, Taxonomies, Provisioning Templates, etc.
 ImportSequence|[ImportSequence](#importsequence)|Imports sequences from an external file. All current properties should be sent to that file.
 <a name="provisioningtemplate"></a>
-###ProvisioningTemplate
+### ProvisioningTemplate
 Represents the root element of the SharePoint Provisioning Template.
 
 ```xml
@@ -117,10 +117,10 @@ DisplayName|xsd:string|The Display Name of the Provisioning Template, optional a
 Description|xsd:string|The Description of the Provisioning Template, optional attribute.
 
 
-##Child Elements and Complex Types
+## Child Elements and Complex Types
 Here follows the list of all the other child elements and complex types that can be used in the PnP Provisioning Schema.
 <a name="preferences"></a>
-###Preferences
+### Preferences
 General settings for a Provisioning file.
 
 ```xml
@@ -149,7 +149,7 @@ Version|xsd:string|Provisioning File Version number, optional attribute.
 Author|xsd:string|Provisioning File Author name, optional attribute.
 Generator|xsd:string|Name of the tool generating this Provisioning File, optional attribute.
 <a name="parameters"></a>
-###Parameters
+### Parameters
 Definition of parameters that can be used as replacement within templates and provisioning objects.
 
 ```xml
@@ -166,7 +166,7 @@ Element|Type|Description
 -------|----|-----------
 Parameter|[Parameter](#parameter)|A Parameter that can be used as a replacement within templates and provisioning objects.
 <a name="localizations"></a>
-###Localizations
+### Localizations
 An optional list of localizations files to include.
 
 ```xml
@@ -183,7 +183,7 @@ Element|Type|Description
 -------|----|-----------
 Localization|[Localization](#localization)|A Localization element
 <a name="localization"></a>
-###Localization
+### Localization
 A Localization element
 
 ```xml
@@ -204,7 +204,7 @@ LCID|xsd:int|The Locale ID of a Localization Language, required attribute.
 Name|xsd:string|The Name of a Localization Language, required attribute.
 ResourceFile|xsd:string|The path to the .RESX (XML) resource file for the current Localization, required attribute.
 <a name="templates"></a>
-###Templates
+### Templates
 SharePoint Templates, which can be inline or references to external files.
 
 ```xml
@@ -233,7 +233,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:ID|A unique identifier of the Templates collection, optional attribute.
 <a name="sitefields"></a>
-###SiteFields
+### SiteFields
 The Site Columns of the Provisioning Template, optional element.
 
 ```xml
@@ -243,7 +243,7 @@ The Site Columns of the Provisioning Template, optional element.
 ```
 
 <a name="contenttypes"></a>
-###ContentTypes
+### ContentTypes
 The Content Types of the Provisioning Template, optional element.
 
 ```xml
@@ -260,7 +260,7 @@ Element|Type|Description
 -------|----|-----------
 ContentType|[ContentType](#contenttype)|
 <a name="lists"></a>
-###Lists
+### Lists
 The Lists instances of the Provisioning Template, optional element.
 
 ```xml
@@ -277,7 +277,7 @@ Element|Type|Description
 -------|----|-----------
 ListInstance|[ListInstance](#listinstance)|
 <a name="files"></a>
-###Files
+### Files
 The Files to provision into the target Site through the Provisioning Template, optional element.
 
 ```xml
@@ -294,7 +294,7 @@ Element|Type|Description
 -------|----|-----------
 File|[File](#file)|
 <a name="termgroups"></a>
-###TermGroups
+### TermGroups
 The TermGroups element allows provisioning one or more TermGroups into the target Site, optional element.
 
 ```xml
@@ -311,7 +311,7 @@ Element|Type|Description
 -------|----|-----------
 TermGroup|[TermGroup](#termgroup)|The TermGroup element to provision into the target Site through the Provisioning Template, optional element.
 <a name="searchsettings"></a>
-###SearchSettings
+### SearchSettings
 The Search Settings for the Provisioning Template, optional element.
 
 ```xml
@@ -321,7 +321,7 @@ The Search Settings for the Provisioning Template, optional element.
 ```
 
 <a name="providers"></a>
-###Providers
+### Providers
 The Extensiblity Providers to invoke while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -338,7 +338,7 @@ Element|Type|Description
 -------|----|-----------
 Provider|[Provider](#provider)|
 <a name="provisioningtemplateproperties"></a>
-###ProvisioningTemplateProperties
+### ProvisioningTemplateProperties
 A set of custom Properties for the Provisioning Template.
 
 ```xml
@@ -355,7 +355,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A custom Property for the Provisioning Template, collection of elements.
 <a name="websettings"></a>
-###WebSettings
+### WebSettings
 Section of Settings for the current Web Site, optional element.
 
 ```xml
@@ -388,7 +388,7 @@ AlternateCSS|xsd:string|The AlternateCSS of the Site, optional attribute.
 MasterPageUrl|xsd:string|The MasterPage URL of the Site, optional attribute.
 CustomMasterPageUrl|xsd:string|The Custom MasterPage URL of the Site, optional attribute.
 <a name="regionalsettings"></a>
-###RegionalSettings
+### RegionalSettings
 Defines the Regional Settings for a site.
 
 ```xml
@@ -429,7 +429,7 @@ WorkDayEndHour|WorkHour|The the default hour at which the work day ends on the c
 WorkDays|xsd:int|The work days of Web site calendars, optinal attribute.
 WorkDayStartHour|WorkHour|The the default hour at which the work day starts on the calendar that is in use on the server, optinal attribute.
 <a name="supporteduilanguages"></a>
-###SupportedUILanguages
+### SupportedUILanguages
 Defines the Supported UI Languages for a site.
 
 ```xml
@@ -446,7 +446,7 @@ Element|Type|Description
 -------|----|-----------
 SupportedUILanguage|[SupportedUILanguage](#supporteduilanguage)|Defines a single Supported UI Language for a site.
 <a name="supporteduilanguage"></a>
-###SupportedUILanguage
+### SupportedUILanguage
 Defines a single Supported UI Language for a site.
 
 ```xml
@@ -463,7 +463,7 @@ Attibute|Type|Description
 --------|----|-----------
 LCID|xsd:int|The Locale ID of a Supported UI Language, required attribute.
 <a name="auditsettings"></a>
-###AuditSettings
+### AuditSettings
 The Audit Settings for the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -490,7 +490,7 @@ Attibute|Type|Description
 AuditLogTrimmingRetention|xsd:int|The Audit Log Trimming Retention for Audits, optional attribute.
 TrimAuditLog|xsd:boolean|A flag to enable Audit Log Trimming, optional attribute.
 <a name="audit"></a>
-###Audit
+### Audit
 A single Audit setting defined by an AuditFlag.
 
 ```xml
@@ -507,7 +507,7 @@ Attibute|Type|Description
 --------|----|-----------
 AuditFlag||An Audit Flag for a single Audit setting, required attribute.
 <a name="propertybagentries"></a>
-###PropertyBagEntries
+### PropertyBagEntries
 The Property Bag entries of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -524,7 +524,7 @@ Element|Type|Description
 -------|----|-----------
 PropertyBagEntry|[PropertyBagEntry](#propertybagentry)|
 <a name="security"></a>
-###Security
+### Security
 The Security configurations of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -551,7 +551,7 @@ AdditionalVisitors|[UsersList](#userslist)|List of additional Visitors for the S
 SiteGroups|[SiteGroups](#sitegroups)|List of additional Groups for the Site, optional collection of elements.
 Permissions|[Permissions](#permissions)|
 <a name="permissions"></a>
-###Permissions
+### Permissions
 
 
 ```xml
@@ -570,7 +570,7 @@ Element|Type|Description
 RoleDefinitions|[RoleDefinitions](#roledefinitions)|List of Role Definitions for the Site, optional collection of elements.
 RoleAssignments|[RoleAssignments](#roleassignments)|List of Role Assignments for the Site, optional collection of elements.
 <a name="features"></a>
-###Features
+### Features
 The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -589,7 +589,7 @@ Element|Type|Description
 SiteFeatures|[FeaturesList](#featureslist)|The Site Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 WebFeatures|[FeaturesList](#featureslist)|The Web Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 <a name="customactions"></a>
-###CustomActions
+### CustomActions
 The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element.
 
 ```xml
@@ -608,7 +608,7 @@ Element|Type|Description
 SiteCustomActions|[CustomActionsList](#customactionslist)|The Site Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 WebCustomActions|[CustomActionsList](#customactionslist)|The Web Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 <a name="pages"></a>
-###Pages
+### Pages
 The Pages to provision into the target Site through the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -625,7 +625,7 @@ Element|Type|Description
 -------|----|-----------
 Page|[Page](#page)|
 <a name="propertybagentry"></a>
-###PropertyBagEntry
+### PropertyBagEntry
 The Property Bag Entry of the Provisioning Template.
 
 ```xml
@@ -644,7 +644,7 @@ Attibute|Type|Description
 Overwrite|xsd:boolean|Declares whether the Property Bag Entry has to overwrite an already existing entry, optional attribute.
 Indexed|xsd:boolean|Declares whether the Property Bag Entry has to be indexed, optional attribute.
 <a name="stringdictionaryitem"></a>
-###StringDictionaryItem
+### StringDictionaryItem
 Defines a StringDictionary element.
 
 ```xml
@@ -663,7 +663,7 @@ Attibute|Type|Description
 Key|xsd:string|The Key of the property to store in the StringDictionary, required attribute.
 Value|xsd:string|The Value of the property to store in the StringDictionary, required attribute.
 <a name="userslist"></a>
-###UsersList
+### UsersList
 List of Users for the Site Security, collection of elements.
 
 ```xml
@@ -680,7 +680,7 @@ Element|Type|Description
 -------|----|-----------
 User|[User](#user)|
 <a name="user"></a>
-###User
+### User
 The base type for a User element.
 
 ```xml
@@ -697,7 +697,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the User, required attribute.
 <a name="sitegroups"></a>
-###SiteGroups
+### SiteGroups
 List of Site Groups for the Site Security, collection of elements.
 
 ```xml
@@ -714,7 +714,7 @@ Element|Type|Description
 -------|----|-----------
 SiteGroup|[SiteGroup](#sitegroup)|
 <a name="sitegroup"></a>
-###SiteGroup
+### SiteGroup
 The base type for a Site Group element.
 
 ```xml
@@ -753,7 +753,7 @@ AutoAcceptRequestToJoinLeave|xsd:boolean|Defines whether to auto-accept requests
 OnlyAllowMembersViewMembership|xsd:boolean|Defines whether to allow members only to view the membership of the Site Group, optional attribute.
 RequestToJoinLeaveEmailSetting|xsd:string|Defines the email address used for membership requests to join or leave will be sent for the Site Group, optional attribute.
 <a name="roledefinitions"></a>
-###RoleDefinitions
+### RoleDefinitions
 List of Role Definitions for a target RoleAssignment, collection of elements.
 
 ```xml
@@ -770,7 +770,7 @@ Element|Type|Description
 -------|----|-----------
 RoleDefinition|[RoleDefinition](#roledefinition)|
 <a name="roledefinition"></a>
-###RoleDefinition
+### RoleDefinition
 
 
 ```xml
@@ -797,7 +797,7 @@ Attibute|Type|Description
 Name|xsd:string|Defines the Name of the Role Definition, required attribute.
 Description|xsd:string|Defines the Description of the Role Definition, optional attribute.
 <a name="permissions"></a>
-###Permissions
+### Permissions
 Defines the Permissions of the Role Definition, required element.
 
 ```xml
@@ -814,7 +814,7 @@ Element|Type|Description
 -------|----|-----------
 Permission|[Permission](#permission)|Defines a Permission for a Role Definition.
 <a name="roleassignments"></a>
-###RoleAssignments
+### RoleAssignments
 List of Role Assignments for a target Principal, collection of elements.
 
 ```xml
@@ -831,7 +831,7 @@ Element|Type|Description
 -------|----|-----------
 RoleAssignment|[RoleAssignment](#roleassignment)|
 <a name="roleassignment"></a>
-###RoleAssignment
+### RoleAssignment
 
 
 ```xml
@@ -850,7 +850,7 @@ Attibute|Type|Description
 Principal|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 RoleDefinition|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 <a name="objectsecurity"></a>
-###ObjectSecurity
+### ObjectSecurity
 Defines a set of Role Assignments for specific principals.
 
 ```xml
@@ -867,7 +867,7 @@ Element|Type|Description
 -------|----|-----------
 BreakRoleInheritance|[BreakRoleInheritance](#breakroleinheritance)|
 <a name="breakroleinheritance"></a>
-###BreakRoleInheritance
+### BreakRoleInheritance
 Declares a section of custom permissions, breaking role inheritance from parent.
 
 ```xml
@@ -894,7 +894,7 @@ Attibute|Type|Description
 CopyRoleAssignments|xsd:boolean|Defines whether to copy role assignments or not while breaking role inheritance, required attribute.
 ClearSubscopes|xsd:boolean|Defines whether to clear subscopes or not while breaking role inheritance, required attribute.
 <a name="listinstance"></a>
-###ListInstance
+### ListInstance
 Defines a ListInstance element
 
 ```xml
@@ -967,7 +967,7 @@ Hidden|xsd:boolean|The Hidden flag for the List Instance, optional attribute.
 EnableAttachments|xsd:boolean|The EnableAttachments flag for the List Instance, optional attribute.
 EnableFolderCreation|xsd:boolean|The EnableFolderCreation flag for the List Instance, optional attribute.
 <a name="contenttypebindings"></a>
-###ContentTypeBindings
+### ContentTypeBindings
 The ContentTypeBindings entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -984,7 +984,7 @@ Element|Type|Description
 -------|----|-----------
 ContentTypeBinding|[ContentTypeBinding](#contenttypebinding)|
 <a name="views"></a>
-###Views
+### Views
 The Views entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1002,7 +1002,7 @@ Attibute|Type|Description
 --------|----|-----------
 RemoveExistingViews|xsd:boolean|A flag to declare if the existing views of the List Instance have to be removed, before adding the custom views, optional attribute.
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1012,7 +1012,7 @@ The Fields entries of the List Instance, optional collection of elements.
 ```
 
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1029,7 +1029,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ListInstanceFieldRef](#listinstancefieldref)|
 <a name="datarows"></a>
-###DataRows
+### DataRows
 Defines a collection of rows that will be added to the List Instance, optional element.
 
 ```xml
@@ -1046,7 +1046,7 @@ Element|Type|Description
 -------|----|-----------
 DataRow|[DataRow](#datarow)|
 <a name="folders"></a>
-###Folders
+### Folders
 Defines a collection of folders (eventually nested) that will be provisioned into the target list/library, optional element.
 
 ```xml
@@ -1063,7 +1063,7 @@ Element|Type|Description
 -------|----|-----------
 Folder|[Folder](#folder)|
 <a name="fielddefaults"></a>
-###FieldDefaults
+### FieldDefaults
 Defines a list of default values for the Fields of the List Instance, optional collection of elements.
 
 ```xml
@@ -1080,7 +1080,7 @@ Element|Type|Description
 -------|----|-----------
 FieldDefault|[FieldDefault](#fielddefault)|Defines a default value for a Field of the List Instance.
 <a name="folder"></a>
-###Folder
+### Folder
 Defines a folder that will be provisioned into the target list/library.
 
 ```xml
@@ -1107,7 +1107,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the Folder, required attribute.
 <a name="datavalue"></a>
-###DataValue
+### DataValue
 The DataValue of a single field of a row to insert into a target ListInstance.
 
 ```xml
@@ -1116,7 +1116,7 @@ The DataValue of a single field of a row to insert into a target ListInstance.
 ```
 
 <a name="fielddefault"></a>
-###FieldDefault
+### FieldDefault
 The FieldDefault of a single field of list or library for target ListInstance.
 
 ```xml
@@ -1125,7 +1125,7 @@ The FieldDefault of a single field of list or library for target ListInstance.
 ```
 
 <a name="contenttype"></a>
-###ContentType
+### ContentType
 Defines a Content Type.
 
 ```xml
@@ -1174,7 +1174,7 @@ NewFormUrl|xsd:string|Specifies the URL of a custom new form to use for list ite
 EditFormUrl|xsd:string|Specifies the URL of a custom edit form to use for list items that have been assigned the content type, optional attribute.
 DisplayFormUrl|xsd:string|Specifies the URL of a custom display form to use for list items that have been assigned the content type, optional attribute.
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1191,7 +1191,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ContentTypeFieldRef](#contenttypefieldref)|
 <a name="documenttemplate"></a>
-###DocumentTemplate
+### DocumentTemplate
 Specifies the document template for the content type. This is the file which SharePoint Foundation opens as a template when a user requests a new item of this content type.
 
 ```xml
@@ -1208,7 +1208,7 @@ Attibute|Type|Description
 --------|----|-----------
 TargetName|xsd:string|The value of the Content Type ID, required attribute.
 <a name="contenttypebinding"></a>
-###ContentTypeBinding
+### ContentTypeBinding
 Defines the binding between a ListInstance and a ContentType.
 
 ```xml
@@ -1227,7 +1227,7 @@ Attibute|Type|Description
 ContentTypeID|ContentTypeId|The value of the Content Type ID to bind, required attribute.
 Default|xsd:boolean|Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
 <a name="documentsettemplate"></a>
-###DocumentSetTemplate
+### DocumentSetTemplate
 Defines a DocumentSet Template for creating multiple DocumentSet instances.
 
 ```xml
@@ -1258,7 +1258,7 @@ Attibute|Type|Description
 --------|----|-----------
 WelcomePage|xsd:string|Defines the custom WelcomePage for the Document Set, optional attribute.
 <a name="allowedcontenttypes"></a>
-###AllowedContentTypes
+### AllowedContentTypes
 The list of allowed Content Types for the Document Set, optional element.
 
 ```xml
@@ -1275,7 +1275,7 @@ Element|Type|Description
 -------|----|-----------
 AllowedContentType|[AllowedContentType](#allowedcontenttype)|
 <a name="defaultdocuments"></a>
-###DefaultDocuments
+### DefaultDocuments
 The list of default Documents for the Document Set, optional element.
 
 ```xml
@@ -1292,7 +1292,7 @@ Element|Type|Description
 -------|----|-----------
 DefaultDocument|[DefaultDocument](#defaultdocument)|
 <a name="sharedfields"></a>
-###SharedFields
+### SharedFields
 The list of Shared Fields for the Document Set, optional element.
 
 ```xml
@@ -1309,7 +1309,7 @@ Element|Type|Description
 -------|----|-----------
 SharedField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="welcomepagefields"></a>
-###WelcomePageFields
+### WelcomePageFields
 The list of Welcome Page Fields for the Document Set, optional element.
 
 ```xml
@@ -1326,7 +1326,7 @@ Element|Type|Description
 -------|----|-----------
 WelcomePageField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="featureslist"></a>
-###FeaturesList
+### FeaturesList
 Defines a collection of elements of type Feature.
 
 ```xml
@@ -1343,7 +1343,7 @@ Element|Type|Description
 -------|----|-----------
 Feature|[Feature](#feature)|
 <a name="feature"></a>
-###Feature
+### Feature
 Defines a single Site or Web Feature, which will be activated or deactivated while applying the Provisioning Template.
 
 ```xml
@@ -1364,7 +1364,7 @@ ID|GUID|The unique ID of the Feature, required attribute.
 Deactivate|xsd:boolean|Defines if the feature has to be deactivated or activated while applying the Provisioning Template, optional attribute.
 Description|xsd:string|The Description of the feature, optional attribute.
 <a name="fieldrefbase"></a>
-###FieldRefBase
+### FieldRefBase
 
 
 ```xml
@@ -1381,7 +1381,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|GUID|The value of the field ID to bind, required attribute.
 <a name="fieldreffull"></a>
-###FieldRefFull
+### FieldRefFull
 
 
 ```xml
@@ -1390,7 +1390,7 @@ ID|GUID|The value of the field ID to bind, required attribute.
 ```
 
 <a name="listinstancefieldref"></a>
-###ListInstanceFieldRef
+### ListInstanceFieldRef
 Defines the binding between a ListInstance and a Field.
 
 ```xml
@@ -1407,7 +1407,7 @@ Attibute|Type|Description
 --------|----|-----------
 DisplayName|xsd:string|The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute.
 <a name="contenttypefieldref"></a>
-###ContentTypeFieldRef
+### ContentTypeFieldRef
 Defines the binding between a ContentType and a Field.
 
 ```xml
@@ -1416,7 +1416,7 @@ Defines the binding between a ContentType and a Field.
 ```
 
 <a name="documentsetfieldref"></a>
-###DocumentSetFieldRef
+### DocumentSetFieldRef
 Defines the binding between a Document Set and a Field.
 
 ```xml
@@ -1425,7 +1425,7 @@ Defines the binding between a Document Set and a Field.
 ```
 
 <a name="customactionslist"></a>
-###CustomActionsList
+### CustomActionsList
 Defines a collection of elements of type CustomAction.
 
 ```xml
@@ -1442,7 +1442,7 @@ Element|Type|Description
 -------|----|-----------
 CustomAction|[CustomAction](#customaction)|
 <a name="customaction"></a>
-###CustomAction
+### CustomAction
 Defines a Custom Action, which will be provisioned while applying the Provisioning Template.
 
 ```xml
@@ -1493,7 +1493,7 @@ ScriptSrc|xsd:string|The ScriptSrc of the CustomAction, optional attribute.
 RegistrationId|xsd:string|The RegistrationId of the CustomAction, optional attribute.
 RegistrationType|RegistrationType|The RegistrationType of the CustomAction, optional attribute.
 <a name="commanduiextension"></a>
-###CommandUIExtension
+### CommandUIExtension
 Defines the Custom UI Extension XML, optional element.
 
 ```xml
@@ -1503,7 +1503,7 @@ Defines the Custom UI Extension XML, optional element.
 ```
 
 <a name="fileproperties"></a>
-###FileProperties
+### FileProperties
 A collection of File Properties.
 
 ```xml
@@ -1520,7 +1520,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|
 <a name="file"></a>
-###File
+### File
 Defines a File element, to describe a file that will be provisioned into the target Site.
 
 ```xml
@@ -1553,7 +1553,7 @@ Src|xsd:string|The Src of the File, required attribute.
 Folder|xsd:string|The TargetFolder of the File, required attribute.
 Overwrite|xsd:boolean|The Overwrite flag for the File, optional attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1570,7 +1570,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WebPartPageWebPart](#webpartpagewebpart)|
 <a name="page"></a>
-###Page
+### Page
 Defines a Page element, to describe a page that will be provisioned into the target Site. Because of the Layout attribute, the assumption is made that you're referring/creating a WikiPage.
 
 ```xml
@@ -1603,7 +1603,7 @@ Url|xsd:string|The server relative url of the page, supports tokens, required at
 Overwrite|xsd:boolean|If set, overwrites an existing page in the case of a wikipage, optional attribute.
 Layout|WikiPageLayout|Defines the layout of the wikipage, required attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1620,7 +1620,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WikiPageWebPart](#wikipagewebpart)|
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields to setup for the Page, optional collection of elements.
 
 ```xml
@@ -1637,7 +1637,7 @@ Element|Type|Description
 -------|----|-----------
 Field|[BaseFieldValue](#basefieldvalue)|
 <a name="wikipagewebpart"></a>
-###WikiPageWebPart
+### WikiPageWebPart
 Defines a WebPart to be added to a WikiPage.
 
 ```xml
@@ -1666,7 +1666,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Row|xsd:int|Defines the row to add the WebPart to, required attribute.
 Column|xsd:int|Defines the column to add the WebPart to, required attribute.
 <a name="contents"></a>
-###Contents
+### Contents
 Defines the WebPart XML, required element.
 
 ```xml
@@ -1676,7 +1676,7 @@ Defines the WebPart XML, required element.
 ```
 
 <a name="webpartpagewebpart"></a>
-###WebPartPageWebPart
+### WebPartPageWebPart
 Defines a webpart to be added to a WebPart Page.
 
 ```xml
@@ -1705,7 +1705,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Zone|xsd:string|Defines the zone of a WebPart Page to add the webpart to, required attribute.
 Order|xsd:int|Defines the index of the WebPart in the zone, required attribute.
 <a name="contents"></a>
-###Contents
+### Contents
 Defines the WebPart XML, required element.
 
 ```xml
@@ -1715,7 +1715,7 @@ Defines the WebPart XML, required element.
 ```
 
 <a name="composedlook"></a>
-###ComposedLook
+### ComposedLook
 Defines a ComposedLook element.
 
 ```xml
@@ -1740,7 +1740,7 @@ FontFile|xsd:string|The FontFile of the ComposedLook, required attribute.
 BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute.
 Version|xsd:int|The Version of the ComposedLook, optional attribute.
 <a name="workflows"></a>
-###Workflows
+### Workflows
 Defines the Workflows to provision.
 
 ```xml
@@ -1759,7 +1759,7 @@ Element|Type|Description
 WorkflowDefinitions|[WorkflowDefinitions](#workflowdefinitions)|
 WorkflowSubscriptions|[WorkflowSubscriptions](#workflowsubscriptions)|
 <a name="workflowdefinitions"></a>
-###WorkflowDefinitions
+### WorkflowDefinitions
 Defines the Workflows Definitions to provision.
 
 ```xml
@@ -1776,7 +1776,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowDefinition|[WorkflowDefinition](#workflowdefinition)|
 <a name="workflowsubscriptions"></a>
-###WorkflowSubscriptions
+### WorkflowSubscriptions
 Defines the Workflows Subscriptions to provision.
 
 ```xml
@@ -1793,7 +1793,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowSubscription|[WorkflowSubscription](#workflowsubscription)|
 <a name="addins"></a>
-###AddIns
+### AddIns
 Defines the SharePoint Add-ins to provision, collection of elements.
 
 ```xml
@@ -1810,7 +1810,7 @@ Element|Type|Description
 -------|----|-----------
 Addin|[Addin](#addin)|
 <a name="addin"></a>
-###Addin
+### Addin
 
 
 ```xml
@@ -1829,7 +1829,7 @@ Attibute|Type|Description
 PackagePath|xsd:string|Defines the .app file of the SharePoint Add-in to provision, required attribute.
 Source||Defines the Source of the SharePoint Add-in to provision, required attribute.
 <a name="publishing"></a>
-###Publishing
+### Publishing
 Defines the Publishing configuration to provision.
 
 ```xml
@@ -1858,7 +1858,7 @@ Attibute|Type|Description
 --------|----|-----------
 AutoCheckRequirements||Defines how an engine should behave if the requirements for provisioning publishing capabilities are not satisfied by the target site, required attribute.
 <a name="designpackage"></a>
-###DesignPackage
+### DesignPackage
 Defines a Design Package to import into the current Publishing site, optional element.
 
 ```xml
@@ -1883,7 +1883,7 @@ MinorVersion|xsd:int|The Minor Version of the Design Package to import into the 
 PackageGuid|GUID|The ID of the Design Package to import into the current Publishing site, optional attribute.
 PackageName|xsd:string|The Name of the Design Package to import into the current Publishing site, required attribute.
 <a name="availablewebtemplates"></a>
-###AvailableWebTemplates
+### AvailableWebTemplates
 Defines the Available Web Templates for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -1900,7 +1900,7 @@ Element|Type|Description
 -------|----|-----------
 WebTemplate|[WebTemplate](#webtemplate)|Defines an available Web Template for the current Publishing site.
 <a name="pagelayouts"></a>
-###PageLayouts
+### PageLayouts
 Defines the Available Page Layouts for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -1925,7 +1925,7 @@ Attibute|Type|Description
 --------|----|-----------
 Default|xsd:string|Defines the URL of the Default Page Layout for the current Publishing site, if any. Optional attribute.
 <a name="provider"></a>
-###Provider
+### Provider
 Defines an Extensibility Provider.
 
 ```xml
@@ -1952,7 +1952,7 @@ Attibute|Type|Description
 Enabled|xsd:boolean|Defines whether the Extensibility Provider is enabled or not, optional attribute.
 HandlerType|xsd:string|The type of the handler. It can be a FQN of a .NET type, the URL of a node.js file, or whatever else, required attribute.
 <a name="configuration"></a>
-###Configuration
+### Configuration
 Defines an optional configuration section for the Extensibility Provider. The configuration section can be any XML.
 
 ```xml
@@ -1962,7 +1962,7 @@ Defines an optional configuration section for the Extensibility Provider. The co
 ```
 
 <a name="provisioningtemplatefile"></a>
-###ProvisioningTemplateFile
+### ProvisioningTemplateFile
 An element that references an external file.
 
 ```xml
@@ -1981,7 +1981,7 @@ Attibute|Type|Description
 File|xsd:string|Absolute or relative path to the file, required attribute.
 ID|xsd:ID|ID of the referenced template, required attribute.
 <a name="provisioningtemplatereference"></a>
-###ProvisioningTemplateReference
+### ProvisioningTemplateReference
 An element that references an external file.
 
 ```xml
@@ -1998,7 +1998,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:IDREF|ID of the referenced template, required attribute.
 <a name="sequence"></a>
-###Sequence
+### Sequence
 Each Provisioning file is split into a set of Sequence elements. The Sequence element groups the artefacts to be provisioned into groups. The Sequences must be evaluated by the provisioning engine in the order in which they appear.
 
 ```xml
@@ -2031,7 +2031,7 @@ Attibute|Type|Description
 SequenceType||Instructions to the Provisioning engine on how the Containers within the Sequence can be provisioned.
 ID|xsd:ID|A unique identifier of the Sequence, required attribute.
 <a name="sitecollection"></a>
-###SiteCollection
+### SiteCollection
 Defines a SiteCollection that will be created into the target tenant/farm.
 
 ```xml
@@ -2056,7 +2056,7 @@ Attibute|Type|Description
 --------|----|-----------
 Url|ReplaceableString|Absolute Url to the site, required attribute.
 <a name="site"></a>
-###Site
+### Site
 Defines a Site that will be created into a target Site Collection.
 
 ```xml
@@ -2083,7 +2083,7 @@ Attibute|Type|Description
 UseSamePermissionsAsParentSite|xsd:boolean|
 Url|ReplaceableString|Relative Url to the site, required attribute.
 <a name="termstore"></a>
-###TermStore
+### TermStore
 A TermStore to use for provisioning of TermGroups.
 
 ```xml
@@ -2108,7 +2108,7 @@ Attibute|Type|Description
 --------|----|-----------
 Scope||The scope of the term store, required attribute.
 <a name="termgroup"></a>
-###TermGroup
+### TermGroup
 A TermGroup to use for provisioning of TermSets and Terms.
 
 ```xml
@@ -2131,7 +2131,7 @@ SiteCollectionTermGroup|xsd:boolean|Declares if the TermGroup is the Site Collec
 Name|xsd:string|The Name of the Taxonomy Item, required attribute.
 ID|GUID|The ID of the Taxonomy Item, optional attribute.
 <a name="termsetitem"></a>
-###TermSetItem
+### TermSetItem
 Base type for TermSets and Terms
 
 ```xml
@@ -2152,7 +2152,7 @@ Owner|xsd:string|The Owner of the Term Set Item, optional attribute.
 Description|xsd:string|The Description of the Term Set Item, optional attribute.
 IsAvailableForTagging|xsd:boolean|Declares whether the Term Set Item is available for tagging, optional attribute.
 <a name="termset"></a>
-###TermSet
+### TermSet
 A TermSet to provision.
 
 ```xml
@@ -2171,7 +2171,7 @@ Attibute|Type|Description
 Language|xsd:int|The reference Language for the Term Set, optional attribute.
 IsOpenForTermCreation|xsd:boolean|Declares whether the Term Set is open for terms creation or not, optional attribute.
 <a name="term"></a>
-###Term
+### Term
 A Term to provision into a TermSet or a hyerarchical Term.
 
 ```xml
@@ -2198,7 +2198,7 @@ IsSourceTerm|xsd:boolean|If the IsReused property is set to false, the current T
 IsDeprecated|xsd:boolean|Declares if this term is deprecated, optional attribute.
 SourceTermId|GUID|The ID of the source term if this term is reused, optional attribute.
 <a name="taxonomyitemproperties"></a>
-###TaxonomyItemProperties
+### TaxonomyItemProperties
 A collection of Term Properties.
 
 ```xml
@@ -2215,7 +2215,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A Term Property, collection of elements.
 <a name="termlabels"></a>
-###TermLabels
+### TermLabels
 A collection of Term Labels, in order to support multi-language terms.
 
 ```xml
@@ -2232,7 +2232,7 @@ Element|Type|Description
 -------|----|-----------
 Label|[Label](#label)|
 <a name="label"></a>
-###Label
+### Label
 
 
 ```xml
@@ -2253,7 +2253,7 @@ Language|xsd:int|The reference Language for the Term Label, required attribute.
 Value|xsd:string|The Value for the Term Label, required attribute.
 IsDefaultForLanguage|xsd:boolean|Declares whether the current Label is the default for the specific Language, optional attribute.
 <a name="termsets"></a>
-###TermSets
+### TermSets
 A collection of TermSets to provision.
 
 ```xml
@@ -2270,7 +2270,7 @@ Element|Type|Description
 -------|----|-----------
 TermSet|[TermSet](#termset)|A Term Set, optional collection of elements.
 <a name="extensions"></a>
-###Extensions
+### Extensions
 Extensions are custom XML elements and instructions that can be extensions of this default schema or vendor or engine specific extensions.
 
 ```xml
@@ -2280,7 +2280,7 @@ Extensions are custom XML elements and instructions that can be extensions of th
 ```
 
 <a name="importsequence"></a>
-###ImportSequence
+### ImportSequence
 Imports sequences from an external file. All current properties should be sent to that file.
 
 ```xml

--- a/ProvisioningSchema-2016-05.md
+++ b/ProvisioningSchema-2016-05.md
@@ -1,20 +1,20 @@
 ﻿
-#PnP Provisioning Schema
+# PnP Provisioning Schema
 ----------
 *Topic automatically generated on 09/08/2016*
 
-##Namespace
+## Namespace
 The namespace of the PnP Provisioning Schema is:
 
 http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema
 
 All the elements have to be declared with that namespace reference.
 
-##Root Elements
+## Root Elements
 Here follows the list of root elements available in the PnP Provisioning Schema.
   
 <a name="provisioning"></a>
-###Provisioning
+### Provisioning
 
 
 ```xml
@@ -40,7 +40,7 @@ Templates|[Templates](#templates)|An optional section made of provisioning templ
 Sequence|[Sequence](#sequence)|An optional section made of provisioning sequences, which can include Sites, Site Collections, Taxonomies, Provisioning Templates, etc.
 ImportSequence|[ImportSequence](#importsequence)|Imports sequences from an external file. All current properties should be sent to that file.
 <a name="provisioningtemplate"></a>
-###ProvisioningTemplate
+### ProvisioningTemplate
 Represents the root element of the SharePoint Provisioning Template.
 
 ```xml
@@ -121,10 +121,10 @@ DisplayName|xsd:string|The Display Name of the Provisioning Template, optional a
 Description|xsd:string|The Description of the Provisioning Template, optional attribute.
 
 
-##Child Elements and Complex Types
+## Child Elements and Complex Types
 Here follows the list of all the other child elements and complex types that can be used in the PnP Provisioning Schema.
 <a name="preferences"></a>
-###Preferences
+### Preferences
 General settings for a Provisioning file.
 
 ```xml
@@ -153,7 +153,7 @@ Version|xsd:string|Provisioning File Version number, optional attribute.
 Author|xsd:string|Provisioning File Author name, optional attribute.
 Generator|xsd:string|Name of the tool generating this Provisioning File, optional attribute.
 <a name="parameters"></a>
-###Parameters
+### Parameters
 Definition of parameters that can be used as replacement within templates and provisioning objects.
 
 ```xml
@@ -170,7 +170,7 @@ Element|Type|Description
 -------|----|-----------
 Parameter|[Parameter](#parameter)|A Parameter that can be used as a replacement within templates and provisioning objects.
 <a name="localizations"></a>
-###Localizations
+### Localizations
 An optional list of localizations files to include.
 
 ```xml
@@ -187,7 +187,7 @@ Element|Type|Description
 -------|----|-----------
 Localization|[Localization](#localization)|A Localization element
 <a name="localization"></a>
-###Localization
+### Localization
 A Localization element
 
 ```xml
@@ -208,7 +208,7 @@ LCID|xsd:int|The Locale ID of a Localization Language, required attribute.
 Name|xsd:string|The Name of a Localization Language, required attribute.
 ResourceFile|xsd:string|The path to the .RESX (XML) resource file for the current Localization, required attribute.
 <a name="templates"></a>
-###Templates
+### Templates
 SharePoint Templates, which can be inline or references to external files.
 
 ```xml
@@ -237,7 +237,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:ID|A unique identifier of the Templates collection, optional attribute.
 <a name="sitefields"></a>
-###SiteFields
+### SiteFields
 The Site Columns of the Provisioning Template, optional element.
 
 ```xml
@@ -247,7 +247,7 @@ The Site Columns of the Provisioning Template, optional element.
 ```
 
 <a name="contenttypes"></a>
-###ContentTypes
+### ContentTypes
 The Content Types of the Provisioning Template, optional element.
 
 ```xml
@@ -264,7 +264,7 @@ Element|Type|Description
 -------|----|-----------
 ContentType|[ContentType](#contenttype)|
 <a name="lists"></a>
-###Lists
+### Lists
 The Lists instances of the Provisioning Template, optional element.
 
 ```xml
@@ -281,7 +281,7 @@ Element|Type|Description
 -------|----|-----------
 ListInstance|[ListInstance](#listinstance)|
 <a name="files"></a>
-###Files
+### Files
 The Files to provision into the target Site through the Provisioning Template, optional element.
 
 ```xml
@@ -300,7 +300,7 @@ Element|Type|Description
 File|[File](#file)|
 Directory|[Directory](#directory)|
 <a name="termgroups"></a>
-###TermGroups
+### TermGroups
 The TermGroups element allows provisioning one or more TermGroups into the target Site, optional element.
 
 ```xml
@@ -317,7 +317,7 @@ Element|Type|Description
 -------|----|-----------
 TermGroup|[TermGroup](#termgroup)|The TermGroup element to provision into the target Site through the Provisioning Template, optional element.
 <a name="searchsettings"></a>
-###SearchSettings
+### SearchSettings
 The Search Settings for the Provisioning Template, optional element.
 
 ```xml
@@ -336,7 +336,7 @@ Element|Type|Description
 SiteSearchSettings|[SiteSearchSettings](#sitesearchsettings)|The Search Settings for the Site Collection, optional element.
 WebSearchSettings|[WebSearchSettings](#websearchsettings)|The Search Settings for the Site, optional element.
 <a name="providers"></a>
-###Providers
+### Providers
 The Extensiblity Providers to invoke while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -353,7 +353,7 @@ Element|Type|Description
 -------|----|-----------
 Provider|[Provider](#provider)|
 <a name="provisioningtemplateproperties"></a>
-###ProvisioningTemplateProperties
+### ProvisioningTemplateProperties
 A set of custom Properties for the Provisioning Template.
 
 ```xml
@@ -370,7 +370,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A custom Property for the Provisioning Template, collection of elements.
 <a name="websettings"></a>
-###WebSettings
+### WebSettings
 Section of Settings for the current Web Site, optional element.
 
 ```xml
@@ -403,7 +403,7 @@ AlternateCSS|xsd:string|The AlternateCSS of the Site, optional attribute.
 MasterPageUrl|xsd:string|The MasterPage URL of the Site, optional attribute.
 CustomMasterPageUrl|xsd:string|The Custom MasterPage URL of the Site, optional attribute.
 <a name="regionalsettings"></a>
-###RegionalSettings
+### RegionalSettings
 Defines the Regional Settings for a site.
 
 ```xml
@@ -444,7 +444,7 @@ WorkDayEndHour|WorkHour|The the default hour at which the work day ends on the c
 WorkDays|xsd:int|The work days of Web site calendars, optinal attribute.
 WorkDayStartHour|WorkHour|The the default hour at which the work day starts on the calendar that is in use on the server, optinal attribute.
 <a name="supporteduilanguages"></a>
-###SupportedUILanguages
+### SupportedUILanguages
 Defines the Supported UI Languages for a site.
 
 ```xml
@@ -461,7 +461,7 @@ Element|Type|Description
 -------|----|-----------
 SupportedUILanguage|[SupportedUILanguage](#supporteduilanguage)|Defines a single Supported UI Language for a site.
 <a name="supporteduilanguage"></a>
-###SupportedUILanguage
+### SupportedUILanguage
 Defines a single Supported UI Language for a site.
 
 ```xml
@@ -478,7 +478,7 @@ Attibute|Type|Description
 --------|----|-----------
 LCID|xsd:int|The Locale ID of a Supported UI Language, required attribute.
 <a name="auditsettings"></a>
-###AuditSettings
+### AuditSettings
 The Audit Settings for the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -505,7 +505,7 @@ Attibute|Type|Description
 AuditLogTrimmingRetention|xsd:int|The Audit Log Trimming Retention for Audits, optional attribute.
 TrimAuditLog|xsd:boolean|A flag to enable Audit Log Trimming, optional attribute.
 <a name="audit"></a>
-###Audit
+### Audit
 A single Audit setting defined by an AuditFlag.
 
 ```xml
@@ -522,7 +522,7 @@ Attibute|Type|Description
 --------|----|-----------
 AuditFlag||An Audit Flag for a single Audit setting, required attribute.
 <a name="propertybagentries"></a>
-###PropertyBagEntries
+### PropertyBagEntries
 The Property Bag entries of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -539,7 +539,7 @@ Element|Type|Description
 -------|----|-----------
 PropertyBagEntry|[PropertyBagEntry](#propertybagentry)|
 <a name="security"></a>
-###Security
+### Security
 The Security configurations of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -578,7 +578,7 @@ BreakRoleInheritance|xsd:boolean|Declares whether the to break role inheritance 
 CopyRoleAssignments|xsd:boolean|Defines whether to copy role assignments or not while breaking role inheritance, optional attribute.
 ClearSubscopes|xsd:boolean|Defines whether to clear subscopes or not while breaking role inheritance, optional attribute.
 <a name="permissions"></a>
-###Permissions
+### Permissions
 
 
 ```xml
@@ -597,7 +597,7 @@ Element|Type|Description
 RoleDefinitions|[RoleDefinitions](#roledefinitions)|List of Role Definitions for the Site, optional collection of elements.
 RoleAssignments|[RoleAssignments](#roleassignments)|List of Role Assignments for the Site, optional collection of elements.
 <a name="navigation"></a>
-###Navigation
+### Navigation
 The Navigation configurations of the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -616,7 +616,7 @@ Element|Type|Description
 GlobalNavigation|[GlobalNavigation](#globalnavigation)|The Global Navigation settings for the Provisioning Template, optional element.
 CurrentNavigation|[CurrentNavigation](#currentnavigation)|The Current Navigation settings for the Provisioning Template, optional element.
 <a name="globalnavigation"></a>
-###GlobalNavigation
+### GlobalNavigation
 The Global Navigation settings for the Provisioning Template, optional element.
 
 ```xml
@@ -643,7 +643,7 @@ Attibute|Type|Description
 --------|----|-----------
 NavigationType||Defines the type of Global Navigation, required attribute.
 <a name="currentnavigation"></a>
-###CurrentNavigation
+### CurrentNavigation
 The Current Navigation settings for the Provisioning Template, optional element.
 
 ```xml
@@ -670,7 +670,7 @@ Attibute|Type|Description
 --------|----|-----------
 NavigationType||Defines the type of Current Navigation, required attribute.
 <a name="managednavigation"></a>
-###ManagedNavigation
+### ManagedNavigation
 Defines the Managed Navigation settings of a site, optional element.
 
 ```xml
@@ -689,7 +689,7 @@ Attibute|Type|Description
 TermStoreId|ReplaceableString|Defines the TermStore ID for the Managed Navigation, required attribute.
 TermSetId|ReplaceableString|Defines the TermSet ID for the Managed Navigation, required attribute.
 <a name="structuralnavigation"></a>
-###StructuralNavigation
+### StructuralNavigation
 Defines the Structural Navigation settings of a site.
 
 ```xml
@@ -714,7 +714,7 @@ Attibute|Type|Description
 --------|----|-----------
 RemoveExistingNodes|xsd:boolean|Defines whether to remove existing nodes before creating those described through this element, required attribute.
 <a name="navigationnode"></a>
-###NavigationNode
+### NavigationNode
 Defines a Navigation Node for the Structural Navigation of a site.
 
 ```xml
@@ -745,7 +745,7 @@ Url|ReplaceableString|Defines the Url of a Navigation Node for the Structural Na
 IsExternal|xsd:boolean|Defines whether the Navigation Node for the Structural Navigation targets an External resource.
 IsVisible|xsd:boolean|Defines whether the Navigation Node for the Structural Navigation is visible or not.
 <a name="features"></a>
-###Features
+### Features
 The Features (Site or Web) to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -764,7 +764,7 @@ Element|Type|Description
 SiteFeatures|[FeaturesList](#featureslist)|The Site Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 WebFeatures|[FeaturesList](#featureslist)|The Web Features to activate or deactivate while applying the Provisioning Template, optional collection of elements.
 <a name="customactions"></a>
-###CustomActions
+### CustomActions
 The Custom Actions (Site or Web) to provision with the Provisioning Template, optional element.
 
 ```xml
@@ -783,7 +783,7 @@ Element|Type|Description
 SiteCustomActions|[CustomActionsList](#customactionslist)|The Site Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 WebCustomActions|[CustomActionsList](#customactionslist)|The Web Custom Actions to provision while applying the Provisioning Template, optional collection of elements.
 <a name="pages"></a>
-###Pages
+### Pages
 The Pages to provision into the target Site through the Provisioning Template, optional collection of elements.
 
 ```xml
@@ -800,7 +800,7 @@ Element|Type|Description
 -------|----|-----------
 Page|[Page](#page)|
 <a name="propertybagentry"></a>
-###PropertyBagEntry
+### PropertyBagEntry
 The Property Bag Entry of the Provisioning Template.
 
 ```xml
@@ -819,7 +819,7 @@ Attibute|Type|Description
 Overwrite|xsd:boolean|Declares whether the Property Bag Entry has to overwrite an already existing entry, optional attribute.
 Indexed|xsd:boolean|Declares whether the Property Bag Entry has to be indexed, optional attribute.
 <a name="stringdictionaryitem"></a>
-###StringDictionaryItem
+### StringDictionaryItem
 Defines a StringDictionary element.
 
 ```xml
@@ -838,7 +838,7 @@ Attibute|Type|Description
 Key|xsd:string|The Key of the property to store in the StringDictionary, required attribute.
 Value|xsd:string|The Value of the property to store in the StringDictionary, required attribute.
 <a name="userslist"></a>
-###UsersList
+### UsersList
 List of Users for the Site Security, collection of elements.
 
 ```xml
@@ -855,7 +855,7 @@ Element|Type|Description
 -------|----|-----------
 User|[User](#user)|
 <a name="user"></a>
-###User
+### User
 The base type for a User element.
 
 ```xml
@@ -872,7 +872,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the User, required attribute.
 <a name="sitegroups"></a>
-###SiteGroups
+### SiteGroups
 List of Site Groups for the Site Security, collection of elements.
 
 ```xml
@@ -889,7 +889,7 @@ Element|Type|Description
 -------|----|-----------
 SiteGroup|[SiteGroup](#sitegroup)|
 <a name="sitegroup"></a>
-###SiteGroup
+### SiteGroup
 The base type for a Site Group element.
 
 ```xml
@@ -928,7 +928,7 @@ AutoAcceptRequestToJoinLeave|xsd:boolean|Defines whether to auto-accept requests
 OnlyAllowMembersViewMembership|xsd:boolean|Defines whether to allow members only to view the membership of the Site Group, optional attribute.
 RequestToJoinLeaveEmailSetting|xsd:string|Defines the email address used for membership requests to join or leave will be sent for the Site Group, optional attribute.
 <a name="roledefinitions"></a>
-###RoleDefinitions
+### RoleDefinitions
 List of Role Definitions for a target RoleAssignment, collection of elements.
 
 ```xml
@@ -945,7 +945,7 @@ Element|Type|Description
 -------|----|-----------
 RoleDefinition|[RoleDefinition](#roledefinition)|
 <a name="roledefinition"></a>
-###RoleDefinition
+### RoleDefinition
 
 
 ```xml
@@ -972,7 +972,7 @@ Attibute|Type|Description
 Name|xsd:string|Defines the Name of the Role Definition, required attribute.
 Description|xsd:string|Defines the Description of the Role Definition, optional attribute.
 <a name="permissions"></a>
-###Permissions
+### Permissions
 Defines the Permissions of the Role Definition, required element.
 
 ```xml
@@ -989,7 +989,7 @@ Element|Type|Description
 -------|----|-----------
 Permission|[Permission](#permission)|Defines a Permission for a Role Definition.
 <a name="roleassignments"></a>
-###RoleAssignments
+### RoleAssignments
 List of Role Assignments for a target Principal, collection of elements.
 
 ```xml
@@ -1006,7 +1006,7 @@ Element|Type|Description
 -------|----|-----------
 RoleAssignment|[RoleAssignment](#roleassignment)|
 <a name="roleassignment"></a>
-###RoleAssignment
+### RoleAssignment
 
 
 ```xml
@@ -1025,7 +1025,7 @@ Attibute|Type|Description
 Principal|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 RoleDefinition|xsd:string|Defines the Role to which the assignment will apply, required attribute.
 <a name="objectsecurity"></a>
-###ObjectSecurity
+### ObjectSecurity
 Defines a set of Role Assignments for specific principals.
 
 ```xml
@@ -1042,7 +1042,7 @@ Element|Type|Description
 -------|----|-----------
 BreakRoleInheritance|[BreakRoleInheritance](#breakroleinheritance)|
 <a name="breakroleinheritance"></a>
-###BreakRoleInheritance
+### BreakRoleInheritance
 Declares a section of custom permissions, breaking role inheritance from parent.
 
 ```xml
@@ -1069,7 +1069,7 @@ Attibute|Type|Description
 CopyRoleAssignments|xsd:boolean|Defines whether to copy role assignments or not while breaking role inheritance, required attribute.
 ClearSubscopes|xsd:boolean|Defines whether to clear subscopes or not while breaking role inheritance, required attribute.
 <a name="listinstance"></a>
-###ListInstance
+### ListInstance
 Defines a ListInstance element
 
 ```xml
@@ -1146,7 +1146,7 @@ Hidden|xsd:boolean|The Hidden flag for the List Instance, optional attribute.
 EnableAttachments|xsd:boolean|The EnableAttachments flag for the List Instance, optional attribute.
 EnableFolderCreation|xsd:boolean|The EnableFolderCreation flag for the List Instance, optional attribute.
 <a name="contenttypebindings"></a>
-###ContentTypeBindings
+### ContentTypeBindings
 The ContentTypeBindings entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1163,7 +1163,7 @@ Element|Type|Description
 -------|----|-----------
 ContentTypeBinding|[ContentTypeBinding](#contenttypebinding)|
 <a name="views"></a>
-###Views
+### Views
 The Views entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1181,7 +1181,7 @@ Attibute|Type|Description
 --------|----|-----------
 RemoveExistingViews|xsd:boolean|A flag to declare if the existing views of the List Instance have to be removed, before adding the custom views, optional attribute.
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1191,7 +1191,7 @@ The Fields entries of the List Instance, optional collection of elements.
 ```
 
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1208,7 +1208,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ListInstanceFieldRef](#listinstancefieldref)|
 <a name="datarows"></a>
-###DataRows
+### DataRows
 Defines a collection of rows that will be added to the List Instance, optional element.
 
 ```xml
@@ -1225,7 +1225,7 @@ Element|Type|Description
 -------|----|-----------
 DataRow|[DataRow](#datarow)|
 <a name="folders"></a>
-###Folders
+### Folders
 Defines a collection of folders (eventually nested) that will be provisioned into the target list/library, optional element.
 
 ```xml
@@ -1242,7 +1242,7 @@ Element|Type|Description
 -------|----|-----------
 Folder|[Folder](#folder)|
 <a name="fielddefaults"></a>
-###FieldDefaults
+### FieldDefaults
 Defines a list of default values for the Fields of the List Instance, optional collection of elements.
 
 ```xml
@@ -1259,7 +1259,7 @@ Element|Type|Description
 -------|----|-----------
 FieldDefault|[FieldDefault](#fielddefault)|Defines a default value for a Field of the List Instance.
 <a name="folder"></a>
-###Folder
+### Folder
 Defines a folder that will be provisioned into the target list/library.
 
 ```xml
@@ -1286,7 +1286,7 @@ Attibute|Type|Description
 --------|----|-----------
 Name|xsd:string|The Name of the Folder, required attribute.
 <a name="datavalue"></a>
-###DataValue
+### DataValue
 The DataValue of a single field of a row to insert into a target ListInstance.
 
 ```xml
@@ -1295,7 +1295,7 @@ The DataValue of a single field of a row to insert into a target ListInstance.
 ```
 
 <a name="fielddefault"></a>
-###FieldDefault
+### FieldDefault
 The FieldDefault of a single field of list or library for target ListInstance.
 
 ```xml
@@ -1304,7 +1304,7 @@ The FieldDefault of a single field of list or library for target ListInstance.
 ```
 
 <a name="contenttype"></a>
-###ContentType
+### ContentType
 Defines a Content Type.
 
 ```xml
@@ -1353,7 +1353,7 @@ NewFormUrl|xsd:string|Specifies the URL of a custom new form to use for list ite
 EditFormUrl|xsd:string|Specifies the URL of a custom edit form to use for list items that have been assigned the content type, optional attribute.
 DisplayFormUrl|xsd:string|Specifies the URL of a custom display form to use for list items that have been assigned the content type, optional attribute.
 <a name="fieldrefs"></a>
-###FieldRefs
+### FieldRefs
 The FieldRefs entries of the List Instance, optional collection of elements.
 
 ```xml
@@ -1370,7 +1370,7 @@ Element|Type|Description
 -------|----|-----------
 FieldRef|[ContentTypeFieldRef](#contenttypefieldref)|
 <a name="documenttemplate"></a>
-###DocumentTemplate
+### DocumentTemplate
 Specifies the document template for the content type. This is the file which SharePoint Foundation opens as a template when a user requests a new item of this content type.
 
 ```xml
@@ -1387,7 +1387,7 @@ Attibute|Type|Description
 --------|----|-----------
 TargetName|xsd:string|The value of the Content Type ID, required attribute.
 <a name="contenttypebinding"></a>
-###ContentTypeBinding
+### ContentTypeBinding
 Defines the binding between a ListInstance and a ContentType.
 
 ```xml
@@ -1408,7 +1408,7 @@ ContentTypeID|ContentTypeId|The value of the Content Type ID to bind, required a
 Default|xsd:boolean|Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
 Remove|xsd:boolean|Declares if the Content Type should be Removed from the list or library, optional attribute.
 <a name="documentsettemplate"></a>
-###DocumentSetTemplate
+### DocumentSetTemplate
 Defines a DocumentSet Template for creating multiple DocumentSet instances.
 
 ```xml
@@ -1439,7 +1439,7 @@ Attibute|Type|Description
 --------|----|-----------
 WelcomePage|xsd:string|Defines the custom WelcomePage for the Document Set, optional attribute.
 <a name="allowedcontenttypes"></a>
-###AllowedContentTypes
+### AllowedContentTypes
 The list of allowed Content Types for the Document Set, optional element.
 
 ```xml
@@ -1456,7 +1456,7 @@ Element|Type|Description
 -------|----|-----------
 AllowedContentType|[AllowedContentType](#allowedcontenttype)|
 <a name="defaultdocuments"></a>
-###DefaultDocuments
+### DefaultDocuments
 The list of default Documents for the Document Set, optional element.
 
 ```xml
@@ -1473,7 +1473,7 @@ Element|Type|Description
 -------|----|-----------
 DefaultDocument|[DefaultDocument](#defaultdocument)|
 <a name="sharedfields"></a>
-###SharedFields
+### SharedFields
 The list of Shared Fields for the Document Set, optional element.
 
 ```xml
@@ -1490,7 +1490,7 @@ Element|Type|Description
 -------|----|-----------
 SharedField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="welcomepagefields"></a>
-###WelcomePageFields
+### WelcomePageFields
 The list of Welcome Page Fields for the Document Set, optional element.
 
 ```xml
@@ -1507,7 +1507,7 @@ Element|Type|Description
 -------|----|-----------
 WelcomePageField|[DocumentSetFieldRef](#documentsetfieldref)|
 <a name="featureslist"></a>
-###FeaturesList
+### FeaturesList
 Defines a collection of elements of type Feature.
 
 ```xml
@@ -1524,7 +1524,7 @@ Element|Type|Description
 -------|----|-----------
 Feature|[Feature](#feature)|
 <a name="feature"></a>
-###Feature
+### Feature
 Defines a single Site or Web Feature, which will be activated or deactivated while applying the Provisioning Template.
 
 ```xml
@@ -1545,7 +1545,7 @@ ID|GUID|The unique ID of the Feature, required attribute.
 Deactivate|xsd:boolean|Defines if the feature has to be deactivated or activated while applying the Provisioning Template, optional attribute.
 Description|xsd:string|The Description of the feature, optional attribute.
 <a name="fieldrefbase"></a>
-###FieldRefBase
+### FieldRefBase
 
 
 ```xml
@@ -1562,7 +1562,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|GUID|The value of the field ID to bind, required attribute.
 <a name="fieldreffull"></a>
-###FieldRefFull
+### FieldRefFull
 
 
 ```xml
@@ -1571,7 +1571,7 @@ ID|GUID|The value of the field ID to bind, required attribute.
 ```
 
 <a name="listinstancefieldref"></a>
-###ListInstanceFieldRef
+### ListInstanceFieldRef
 Defines the binding between a ListInstance and a Field.
 
 ```xml
@@ -1588,7 +1588,7 @@ Attibute|Type|Description
 --------|----|-----------
 DisplayName|xsd:string|The display name of the field to bind, only applicable to fields that will be added to lists, optional attribute.
 <a name="contenttypefieldref"></a>
-###ContentTypeFieldRef
+### ContentTypeFieldRef
 Defines the binding between a ContentType and a Field.
 
 ```xml
@@ -1597,7 +1597,7 @@ Defines the binding between a ContentType and a Field.
 ```
 
 <a name="documentsetfieldref"></a>
-###DocumentSetFieldRef
+### DocumentSetFieldRef
 Defines the binding between a Document Set and a Field.
 
 ```xml
@@ -1606,7 +1606,7 @@ Defines the binding between a Document Set and a Field.
 ```
 
 <a name="customactionslist"></a>
-###CustomActionsList
+### CustomActionsList
 Defines a collection of elements of type CustomAction.
 
 ```xml
@@ -1623,7 +1623,7 @@ Element|Type|Description
 -------|----|-----------
 CustomAction|[CustomAction](#customaction)|
 <a name="customaction"></a>
-###CustomAction
+### CustomAction
 Defines a Custom Action, which will be provisioned while applying the Provisioning Template.
 
 ```xml
@@ -1676,7 +1676,7 @@ ScriptSrc|xsd:string|The ScriptSrc of the CustomAction, optional attribute.
 RegistrationId|xsd:string|The RegistrationId of the CustomAction, optional attribute.
 RegistrationType|RegistrationType|The RegistrationType of the CustomAction, optional attribute.
 <a name="commanduiextension"></a>
-###CommandUIExtension
+### CommandUIExtension
 Defines the Custom UI Extension XML, optional element.
 
 ```xml
@@ -1686,7 +1686,7 @@ Defines the Custom UI Extension XML, optional element.
 ```
 
 <a name="fileproperties"></a>
-###FileProperties
+### FileProperties
 A collection of File Properties.
 
 ```xml
@@ -1703,7 +1703,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|
 <a name="file"></a>
-###File
+### File
 Defines a File element, to describe a file that will be provisioned into the target Site.
 
 ```xml
@@ -1738,7 +1738,7 @@ Folder|xsd:string|The TargetFolder of the File, required attribute.
 Overwrite|xsd:boolean|The Overwrite flag for the File, optional attribute.
 Level|FileLevel|The Level status for the File, optional attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1755,7 +1755,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WebPartPageWebPart](#webpartpagewebpart)|
 <a name="directory"></a>
-###Directory
+### Directory
 Defines a Directory element, to describe a folder in the current repository that will be used to upload files into the target Site.
 
 ```xml
@@ -1794,7 +1794,7 @@ IncludedExtensions|xsd:string|The file Extensions to include while uploading the
 ExcludedExtensions|xsd:string|The file Extensions to exclude while uploading the Directory, optional attribute.
 MetadataMappingFile|ReplaceableString|The file path of JSON mapping file with metadata for files to upload in the Directory, optional attribute.
 <a name="page"></a>
-###Page
+### Page
 Defines a Page element, to describe a page that will be provisioned into the target Site. Because of the Layout attribute, the assumption is made that you're referring/creating a WikiPage.
 
 ```xml
@@ -1827,7 +1827,7 @@ Url|xsd:string|The server relative url of the page, supports tokens, required at
 Overwrite|xsd:boolean|If set, overwrites an existing page in the case of a wikipage, optional attribute.
 Layout|WikiPageLayout|Defines the layout of the wikipage, required attribute.
 <a name="webparts"></a>
-###WebParts
+### WebParts
 The webparts to add to the page, optional collection of elements.
 
 ```xml
@@ -1844,7 +1844,7 @@ Element|Type|Description
 -------|----|-----------
 WebPart|[WikiPageWebPart](#wikipagewebpart)|
 <a name="fields"></a>
-###Fields
+### Fields
 The Fields to setup for the Page, optional collection of elements.
 
 ```xml
@@ -1861,7 +1861,7 @@ Element|Type|Description
 -------|----|-----------
 Field|[BaseFieldValue](#basefieldvalue)|
 <a name="wikipagewebpart"></a>
-###WikiPageWebPart
+### WikiPageWebPart
 Defines a WebPart to be added to a WikiPage.
 
 ```xml
@@ -1890,7 +1890,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Row|xsd:int|Defines the row to add the WebPart to, required attribute.
 Column|xsd:int|Defines the column to add the WebPart to, required attribute.
 <a name="contents"></a>
-###Contents
+### Contents
 Defines the WebPart XML, required element.
 
 ```xml
@@ -1900,7 +1900,7 @@ Defines the WebPart XML, required element.
 ```
 
 <a name="webpartpagewebpart"></a>
-###WebPartPageWebPart
+### WebPartPageWebPart
 Defines a webpart to be added to a WebPart Page.
 
 ```xml
@@ -1929,7 +1929,7 @@ Title|xsd:string|Defines the title of the WebPart, required attribute.
 Zone|xsd:string|Defines the zone of a WebPart Page to add the webpart to, required attribute.
 Order|xsd:int|Defines the index of the WebPart in the zone, required attribute.
 <a name="contents"></a>
-###Contents
+### Contents
 Defines the WebPart XML, required element.
 
 ```xml
@@ -1939,7 +1939,7 @@ Defines the WebPart XML, required element.
 ```
 
 <a name="composedlook"></a>
-###ComposedLook
+### ComposedLook
 Defines a ComposedLook element.
 
 ```xml
@@ -1964,7 +1964,7 @@ FontFile|xsd:string|The FontFile of the ComposedLook, required attribute.
 BackgroundFile|xsd:string|The BackgroundFile of the ComposedLook, optional attribute.
 Version|xsd:int|The Version of the ComposedLook, optional attribute.
 <a name="workflows"></a>
-###Workflows
+### Workflows
 Defines the Workflows to provision.
 
 ```xml
@@ -1983,7 +1983,7 @@ Element|Type|Description
 WorkflowDefinitions|[WorkflowDefinitions](#workflowdefinitions)|
 WorkflowSubscriptions|[WorkflowSubscriptions](#workflowsubscriptions)|
 <a name="workflowdefinitions"></a>
-###WorkflowDefinitions
+### WorkflowDefinitions
 Defines the Workflows Definitions to provision.
 
 ```xml
@@ -2000,7 +2000,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowDefinition|[WorkflowDefinition](#workflowdefinition)|
 <a name="workflowsubscriptions"></a>
-###WorkflowSubscriptions
+### WorkflowSubscriptions
 Defines the Workflows Subscriptions to provision.
 
 ```xml
@@ -2017,7 +2017,7 @@ Element|Type|Description
 -------|----|-----------
 WorkflowSubscription|[WorkflowSubscription](#workflowsubscription)|
 <a name="addins"></a>
-###AddIns
+### AddIns
 Defines the SharePoint Add-ins to provision, collection of elements.
 
 ```xml
@@ -2034,7 +2034,7 @@ Element|Type|Description
 -------|----|-----------
 Addin|[Addin](#addin)|
 <a name="addin"></a>
-###Addin
+### Addin
 
 
 ```xml
@@ -2053,7 +2053,7 @@ Attibute|Type|Description
 PackagePath|xsd:string|Defines the .app file of the SharePoint Add-in to provision, required attribute.
 Source||Defines the Source of the SharePoint Add-in to provision, required attribute.
 <a name="publishing"></a>
-###Publishing
+### Publishing
 Defines the Publishing configuration to provision.
 
 ```xml
@@ -2082,7 +2082,7 @@ Attibute|Type|Description
 --------|----|-----------
 AutoCheckRequirements||Defines how an engine should behave if the requirements for provisioning publishing capabilities are not satisfied by the target site, required attribute.
 <a name="designpackage"></a>
-###DesignPackage
+### DesignPackage
 Defines a Design Package to import into the current Publishing site, optional element.
 
 ```xml
@@ -2107,7 +2107,7 @@ MinorVersion|xsd:int|The Minor Version of the Design Package to import into the 
 PackageGuid|GUID|The ID of the Design Package to import into the current Publishing site, optional attribute.
 PackageName|xsd:string|The Name of the Design Package to import into the current Publishing site, required attribute.
 <a name="availablewebtemplates"></a>
-###AvailableWebTemplates
+### AvailableWebTemplates
 Defines the Available Web Templates for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -2124,7 +2124,7 @@ Element|Type|Description
 -------|----|-----------
 WebTemplate|[WebTemplate](#webtemplate)|Defines an available Web Template for the current Publishing site.
 <a name="pagelayouts"></a>
-###PageLayouts
+### PageLayouts
 Defines the Available Page Layouts for the current Publishing site, optional collection of elements.
 
 ```xml
@@ -2149,7 +2149,7 @@ Attibute|Type|Description
 --------|----|-----------
 Default|xsd:string|Defines the URL of the Default Page Layout for the current Publishing site, if any. Optional attribute.
 <a name="provider"></a>
-###Provider
+### Provider
 Defines an Extensibility Provider.
 
 ```xml
@@ -2176,7 +2176,7 @@ Attibute|Type|Description
 Enabled|xsd:boolean|Defines whether the Extensibility Provider is enabled or not, optional attribute.
 HandlerType|xsd:string|The type of the handler. It can be a FQN of a .NET type, the URL of a node.js file, or whatever else, required attribute.
 <a name="configuration"></a>
-###Configuration
+### Configuration
 Defines an optional configuration section for the Extensibility Provider. The configuration section can be any XML.
 
 ```xml
@@ -2186,7 +2186,7 @@ Defines an optional configuration section for the Extensibility Provider. The co
 ```
 
 <a name="provisioningtemplatefile"></a>
-###ProvisioningTemplateFile
+### ProvisioningTemplateFile
 An element that references an external file.
 
 ```xml
@@ -2205,7 +2205,7 @@ Attibute|Type|Description
 File|xsd:string|Absolute or relative path to the file, required attribute.
 ID|xsd:ID|ID of the referenced template, required attribute.
 <a name="provisioningtemplatereference"></a>
-###ProvisioningTemplateReference
+### ProvisioningTemplateReference
 An element that references an external file.
 
 ```xml
@@ -2222,7 +2222,7 @@ Attibute|Type|Description
 --------|----|-----------
 ID|xsd:IDREF|ID of the referenced template, required attribute.
 <a name="sequence"></a>
-###Sequence
+### Sequence
 Each Provisioning file is split into a set of Sequence elements. The Sequence element groups the artefacts to be provisioned into groups. The Sequences must be evaluated by the provisioning engine in the order in which they appear.
 
 ```xml
@@ -2255,7 +2255,7 @@ Attibute|Type|Description
 SequenceType||Instructions to the Provisioning engine on how the Containers within the Sequence can be provisioned.
 ID|xsd:ID|A unique identifier of the Sequence, required attribute.
 <a name="sitecollection"></a>
-###SiteCollection
+### SiteCollection
 Defines a SiteCollection that will be created into the target tenant/farm.
 
 ```xml
@@ -2280,7 +2280,7 @@ Attibute|Type|Description
 --------|----|-----------
 Url|ReplaceableString|Absolute Url to the site, required attribute.
 <a name="site"></a>
-###Site
+### Site
 Defines a Site that will be created into a target Site Collection.
 
 ```xml
@@ -2307,7 +2307,7 @@ Attibute|Type|Description
 UseSamePermissionsAsParentSite|xsd:boolean|
 Url|ReplaceableString|Relative Url to the site, required attribute.
 <a name="termstore"></a>
-###TermStore
+### TermStore
 A TermStore to use for provisioning of TermGroups.
 
 ```xml
@@ -2332,7 +2332,7 @@ Attibute|Type|Description
 --------|----|-----------
 Scope||The scope of the term store, required attribute.
 <a name="termgroup"></a>
-###TermGroup
+### TermGroup
 A TermGroup to use for provisioning of TermSets and Terms.
 
 ```xml
@@ -2355,7 +2355,7 @@ SiteCollectionTermGroup|xsd:boolean|Declares if the TermGroup is the Site Collec
 Name|xsd:string|The Name of the Taxonomy Item, required attribute.
 ID|GUID|The ID of the Taxonomy Item, optional attribute.
 <a name="termsetitem"></a>
-###TermSetItem
+### TermSetItem
 Base type for TermSets and Terms
 
 ```xml
@@ -2376,7 +2376,7 @@ Owner|xsd:string|The Owner of the Term Set Item, optional attribute.
 Description|xsd:string|The Description of the Term Set Item, optional attribute.
 IsAvailableForTagging|xsd:boolean|Declares whether the Term Set Item is available for tagging, optional attribute.
 <a name="termset"></a>
-###TermSet
+### TermSet
 A TermSet to provision.
 
 ```xml
@@ -2395,7 +2395,7 @@ Attibute|Type|Description
 Language|xsd:int|The reference Language for the Term Set, optional attribute.
 IsOpenForTermCreation|xsd:boolean|Declares whether the Term Set is open for terms creation or not, optional attribute.
 <a name="term"></a>
-###Term
+### Term
 A Term to provision into a TermSet or a hyerarchical Term.
 
 ```xml
@@ -2422,7 +2422,7 @@ IsSourceTerm|xsd:boolean|If the IsReused property is set to false, the current T
 IsDeprecated|xsd:boolean|Declares if this term is deprecated, optional attribute.
 SourceTermId|GUID|The ID of the source term if this term is reused, optional attribute.
 <a name="taxonomyitemproperties"></a>
-###TaxonomyItemProperties
+### TaxonomyItemProperties
 A collection of Term Properties.
 
 ```xml
@@ -2439,7 +2439,7 @@ Element|Type|Description
 -------|----|-----------
 Property|[StringDictionaryItem](#stringdictionaryitem)|A Term Property, collection of elements.
 <a name="termlabels"></a>
-###TermLabels
+### TermLabels
 A collection of Term Labels, in order to support multi-language terms.
 
 ```xml
@@ -2456,7 +2456,7 @@ Element|Type|Description
 -------|----|-----------
 Label|[Label](#label)|
 <a name="label"></a>
-###Label
+### Label
 
 
 ```xml
@@ -2477,7 +2477,7 @@ Language|xsd:int|The reference Language for the Term Label, required attribute.
 Value|xsd:string|The Value for the Term Label, required attribute.
 IsDefaultForLanguage|xsd:boolean|Declares whether the current Label is the default for the specific Language, optional attribute.
 <a name="termsets"></a>
-###TermSets
+### TermSets
 A collection of TermSets to provision.
 
 ```xml
@@ -2494,7 +2494,7 @@ Element|Type|Description
 -------|----|-----------
 TermSet|[TermSet](#termset)|A Term Set, optional collection of elements.
 <a name="extensions"></a>
-###Extensions
+### Extensions
 Extensions are custom XML elements and instructions that can be extensions of this default schema or vendor or engine specific extensions.
 
 ```xml
@@ -2504,7 +2504,7 @@ Extensions are custom XML elements and instructions that can be extensions of th
 ```
 
 <a name="importsequence"></a>
-###ImportSequence
+### ImportSequence
 Imports sequences from an external file. All current properties should be sent to that file.
 
 ```xml


### PR DESCRIPTION
Add Support to have Folder Properties and ContentType in order to support DocumentSet and Folder for OneNote during Extract/Provision as in Issue #412 

@jansenbe : As ListExtract in https://github.com/SharePoint/PnP-Sites-Core/pull/2326 works as it is, this would allow further support of Folder-Base-Features 