### PR TITLE
Removed default values for several properties

### DIFF
--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -3165,7 +3165,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ListExperience" use="optional" default="Auto">
+    <xsd:attribute name="ListExperience" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3351,7 +3351,7 @@
       </xsd:documentation>
     </xsd:annotation>
 
-    <xsd:attribute name="Enabled" type="xsd:boolean" use="required">
+    <xsd:attribute name="Enabled" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether the IRM settings have to be enabled or not.
@@ -3743,7 +3743,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Default" type="xsd:boolean" use="optional">
+    <xsd:attribute name="Default" type="xsd:boolean" use="optional" default="false">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
@@ -4512,7 +4512,7 @@
               </xsd:restriction>
             </xsd:simpleType>
           </xsd:attribute>
-          <xsd:attribute name="TextAlignment" use="optional">
+          <xsd:attribute name="TextAlignment" use="optional" default="Left">
             <xsd:annotation>
               <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
               <xsd:documentation xml:lang="en">

--- a/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
+++ b/OfficeDevPnP.ProvisioningSchema/ProvisioningSchema-vNext.xsd
@@ -1482,7 +1482,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ExcludeFromOfflineClient" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="ExcludeFromOfflineClient" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1491,7 +1491,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="MembersCanShare" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="MembersCanShare" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1500,7 +1500,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="DisableFlows" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="DisableFlows" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1509,7 +1509,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="DisableAppViews" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="DisableAppViews" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1518,7 +1518,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="HorizontalQuickLaunch" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="HorizontalQuickLaunch" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1584,7 +1584,7 @@
       </xsd:documentation>
     </xsd:annotation>
 
-    <xsd:attribute name="AllowDesigner" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AllowDesigner" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1593,7 +1593,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowCreateDeclarativeWorkflow" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AllowCreateDeclarativeWorkflow" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1602,7 +1602,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowSaveDeclarativeWorkflowAsTemplate" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AllowSaveDeclarativeWorkflowAsTemplate" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1611,7 +1611,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowSavePublishDeclarativeWorkflow" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AllowSavePublishDeclarativeWorkflow" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -1620,7 +1620,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="SocialBarOnSitePagesDisabled" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="SocialBarOnSitePagesDisabled" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -2177,7 +2177,7 @@
         </xsd:annotation>
       </xsd:element>
     </xsd:sequence>
-    <xsd:attribute name="EnableTreeView" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableTreeView" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -2185,7 +2185,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="AddNewPagesToNavigation" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AddNewPagesToNavigation" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201801</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -2193,7 +2193,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="CreateFriendlyUrlsForNewPages" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="CreateFriendlyUrlsForNewPages" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201801</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -2351,7 +2351,7 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="Indexed" type="xsd:boolean" use="optional" default="false">
+        <xsd:attribute name="Indexed" type="xsd:boolean" use="optional">
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               Declares whether the Property Bag Entry has to be indexed, optional attribute.
@@ -3024,7 +3024,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="OnQuickLaunch" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="OnQuickLaunch" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The OnQuickLaunch flag for the List Instance, optional attribute.
@@ -3049,7 +3049,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ForceCheckout" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="ForceCheckout" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The ForceCheckout flag for the List Instance, optional attribute.
@@ -3057,7 +3057,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableVersioning" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableVersioning" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The EnableVersioning flag for the List Instance, optional attribute.
@@ -3065,7 +3065,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableMinorVersions" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableMinorVersions" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The EnableMinorVersions flag for the List Instance, optional attribute.
@@ -3073,7 +3073,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableModeration" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableModeration" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The EnableModeration flag for the List Instance, optional attribute.
@@ -3124,7 +3124,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ContentTypesEnabled" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="ContentTypesEnabled" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The ContentTypesEnabled flag for the List Instance, optional attribute.
@@ -3132,7 +3132,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The Hidden flag for the List Instance, optional attribute.
@@ -3140,7 +3140,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableAttachments" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="EnableAttachments" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The EnableAttachments flag for the List Instance, optional attribute.
@@ -3148,7 +3148,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableFolderCreation" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="EnableFolderCreation" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The EnableFolderCreation flag for the List Instance, optional attribute.
@@ -3156,7 +3156,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="NoCrawl" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="NoCrawl" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3226,7 +3226,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Direction" use="optional" default="NONE">
+    <xsd:attribute name="Direction" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3296,7 +3296,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ReadSecurity" type="xsd:int" use="optional" default="1">
+    <xsd:attribute name="ReadSecurity" type="xsd:int" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3305,7 +3305,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="WriteSecurity" type="xsd:int" use="optional" default="1">
+    <xsd:attribute name="WriteSecurity" type="xsd:int" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201805</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3359,7 +3359,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowPrint" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="AllowPrint" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether a viewer can print the downloaded document.
@@ -3367,7 +3367,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowScript" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="AllowScript" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether a viewer can run a script on the downloaded document.
@@ -3375,7 +3375,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="AllowWriteCopy" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="AllowWriteCopy" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether a viewer can write on a copy of the downloaded document.
@@ -3383,7 +3383,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="DisableDocumentBrowserView" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="DisableDocumentBrowserView" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether to block Office Web Application Companion applications (WACs) from showing this document.
@@ -3407,7 +3407,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableDocumentAccessExpire" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableDocumentAccessExpire" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether the downloaded document will expire.
@@ -3415,7 +3415,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableDocumentBrowserPublishingView" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="EnableDocumentBrowserPublishingView" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether to enable Office Web Application Companion applications (WACs) to publishing view.
@@ -3423,7 +3423,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableGroupProtection" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="EnableGroupProtection" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether the permission of the downloaded document is applicable to a group.
@@ -3431,7 +3431,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableLicenseCacheExpire" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="EnableLicenseCacheExpire" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Defines whether a user must verify their credentials after some interval.
@@ -3668,7 +3668,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Optional Boolean. True to define the content type as hidden. If you define a content type as hidden, SharePoint Foundation does not display that content type on the New button in list views.
@@ -3676,7 +3676,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Sealed" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Sealed" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Optional Boolean. True to prevent changes to this content type. You cannot change the value of this attribute through the user interface, but you can change it in code if you have sufficient rights. You must have site collection administrator rights to unseal a content type.
@@ -3684,7 +3684,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="ReadOnly" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="ReadOnly" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Optional Boolean. TRUE to specify that the content type cannot be edited without explicitly removing the read-only setting. This can be done either in the user interface or in code.
@@ -3743,7 +3743,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Default" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Default" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           Declares if the Content Type should be the default Content Type in the list or library, optional attribute.
@@ -3759,7 +3759,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201705</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -3985,7 +3985,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Required" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Required" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The Required flag for the field to bind, optional attribute.
@@ -3993,7 +3993,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="Hidden" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           The Hidden flag for the field to bind, optional attribute.
@@ -4512,7 +4512,7 @@
               </xsd:restriction>
             </xsd:simpleType>
           </xsd:attribute>
-          <xsd:attribute name="TextAlignment" use="optional" default="Left">
+          <xsd:attribute name="TextAlignment" use="optional">
             <xsd:annotation>
               <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
               <xsd:documentation xml:lang="en">
@@ -4682,7 +4682,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Layout" type="xsd:string" use="optional" default="Article">
+    <xsd:attribute name="Layout" type="xsd:string" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201801</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -4700,7 +4700,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="EnableComments" type="xsd:boolean" use="optional" default="true">
+    <xsd:attribute name="EnableComments" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201801</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -4767,7 +4767,7 @@
       </xsd:simpleType>
     </xsd:attribute>
 
-    <xsd:attribute name="MenuStyle" use="optional" default="Cascading">
+    <xsd:attribute name="MenuStyle" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -4797,7 +4797,7 @@
       </xsd:simpleType>
     </xsd:attribute>
 
-    <xsd:attribute name="BackgroundEmphasis" type="pnp:Emphasis" use="optional" default="None">
+    <xsd:attribute name="BackgroundEmphasis" type="pnp:Emphasis" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -7393,7 +7393,7 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="IsAvailableForTagging" type="xsd:boolean" use="optional" default="true">
+        <xsd:attribute name="IsAvailableForTagging" type="xsd:boolean" use="optional">
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               Declares whether the Term Set Item is available for tagging, optional attribute.
@@ -7441,7 +7441,7 @@
             </xsd:documentation>
           </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="IsOpenForTermCreation" type="xsd:boolean" use="optional" default="false">
+        <xsd:attribute name="IsOpenForTermCreation" type="xsd:boolean" use="optional">
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               Declares whether the Term Set is open for terms creation or not, optional attribute.
@@ -7783,7 +7783,7 @@
 
             <xsd:complexType>
 
-              <xsd:attribute name="AllowGiphy" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowGiphy" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7823,7 +7823,7 @@
 
               </xsd:attribute>
 
-              <xsd:attribute name="AllowStickersAndMemes" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowStickersAndMemes" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7832,7 +7832,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowCustomMemes" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowCustomMemes" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7855,7 +7855,7 @@
 
             <xsd:complexType>
 
-              <xsd:attribute name="AllowCreateUpdateChannels" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowCreateUpdateChannels" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7864,7 +7864,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowDeleteChannels" type="xsd:boolean" use="optional" default="false">
+              <xsd:attribute name="AllowDeleteChannels" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7887,7 +7887,7 @@
 
             <xsd:complexType>
 
-              <xsd:attribute name="AllowCreateUpdateChannels" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowCreateUpdateChannels" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7896,7 +7896,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowDeleteChannels" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowDeleteChannels" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7905,7 +7905,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowAddRemoveApps" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowAddRemoveApps" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7914,7 +7914,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowCreateUpdateRemoveTabs" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowCreateUpdateRemoveTabs" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7923,7 +7923,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowCreateUpdateRemoveConnectors" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowCreateUpdateRemoveConnectors" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7946,7 +7946,7 @@
 
             <xsd:complexType>
 
-              <xsd:attribute name="AllowUserEditMessages" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowUserEditMessages" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7955,7 +7955,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowUserDeleteMessages" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowUserDeleteMessages" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7964,7 +7964,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowOwnerDeleteMessages" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowOwnerDeleteMessages" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7973,7 +7973,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowTeamMentions" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowTeamMentions" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -7982,7 +7982,7 @@
                 </xsd:annotation>
               </xsd:attribute>
 
-              <xsd:attribute name="AllowChannelMentions" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="AllowChannelMentions" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -8014,7 +8014,7 @@
 
             <xsd:complexType>
 
-              <xsd:attribute name="ShowInTeamsSearchAndSuggestions" type="xsd:boolean" use="optional" default="true">
+              <xsd:attribute name="ShowInTeamsSearchAndSuggestions" type="xsd:boolean" use="optional">
                 <xsd:annotation>
                   <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
                   <xsd:documentation xml:lang="en">
@@ -8185,7 +8185,7 @@
           </xsd:annotation>
         </xsd:attribute>
 
-        <xsd:attribute name="Archived" type="xsd:boolean" use="optional" default="false">
+        <xsd:attribute name="Archived" type="xsd:boolean" use="optional">
           <xsd:annotation>
             <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
             <xsd:documentation xml:lang="en">
@@ -8235,7 +8235,7 @@
       </xsd:element>
     </xsd:sequence>
 
-    <xsd:attribute name="AllowToAddGuests" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="AllowToAddGuests" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201909</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -8345,7 +8345,7 @@
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="IsFavoriteByDefault" type="xsd:boolean" use="optional" default="false">
+    <xsd:attribute name="IsFavoriteByDefault" type="xsd:boolean" use="optional">
       <xsd:annotation>
         <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
         <xsd:documentation xml:lang="en">
@@ -8675,7 +8675,7 @@
 
               <xsd:complexType>
 
-                <xsd:attribute name="ForceChangePasswordNextSignIn" type="xsd:boolean" use="optional" default="false">
+                <xsd:attribute name="ForceChangePasswordNextSignIn" type="xsd:boolean" use="optional">
                   <xsd:annotation>
                     <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                     <xsd:documentation xml:lang="en">
@@ -8684,7 +8684,7 @@
                   </xsd:annotation>
                 </xsd:attribute>
 
-                <xsd:attribute name="ForceChangePasswordNextSignInWithMfa" type="xsd:boolean" use="optional" default="false">
+                <xsd:attribute name="ForceChangePasswordNextSignInWithMfa" type="xsd:boolean" use="optional">
                   <xsd:annotation>
                     <xsd:appinfo>Added with schema version 201903</xsd:appinfo>
                     <xsd:documentation xml:lang="en">


### PR DESCRIPTION
Removed the default values from properties that would result in possibly unwanted side effects when provisioning a template if those properties where not specified. If the values on existing sites was different than the default values unexpected changes to the site would happen.
This PR needs update to the provisioning engine that I'm working on.
This PR starts the work on fixing issue [#2413](https://github.com/SharePoint/PnP-Sites-Core/issues/2413) in PnP-Sites-Core